### PR TITLE
Null check on currentDevice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usb-detection",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "Listen to USB devices and detect changes on them.",
   "main": "index.js",
   "gypfile": true,

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -41,7 +41,7 @@ void RegisterAdded(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 void NotifyAdded(ListResultItem_t* it) {
 	Nan::HandleScope scope;
    
-   if (it == null) {
+   if (it == NULL) {
       return;
    }
 
@@ -86,7 +86,7 @@ void RegisterRemoved(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 void NotifyRemoved(ListResultItem_t* it) {
 	Nan::HandleScope scope;
    
-   if (it == null) {
+   if (it == NULL) {
       return;
    }
 

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -40,6 +40,10 @@ void RegisterAdded(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 
 void NotifyAdded(ListResultItem_t* it) {
 	Nan::HandleScope scope;
+   
+   if (it == null) {
+      return;
+   }
 
 	if (isAddedRegistered){
 		v8::Local<v8::Value> argv[1];
@@ -81,6 +85,10 @@ void RegisterRemoved(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 
 void NotifyRemoved(ListResultItem_t* it) {
 	Nan::HandleScope scope;
+   
+   if (it == null) {
+      return;
+   }
 
 	if (isRemovedRegistered) {
 		v8::Local<v8::Value> argv[1];

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -71,14 +71,10 @@ void NotifyAsync(uv_work_t* req) {
 void NotifyFinished(uv_work_t* req) {
 	if (isRunning) {
 		if (isAdded) {
-			if (currentItem !== NULL) {
-				NotifyAdded(currentItem);
-			}
+			NotifyAdded(currentItem);
 		}
 		else {
-			if (currentItem !== NULL) {
-				NotifyRemoved(currentItem);
-			}
+			NotifyRemoved(currentItem);
 		}
 	}
 

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -1,5 +1,5 @@
 #include <libudev.h>
-#include <pthread.h> 
+#include <pthread.h>
 
 #include "detection.h"
 #include "deviceList.h"
@@ -71,10 +71,14 @@ void NotifyAsync(uv_work_t* req) {
 void NotifyFinished(uv_work_t* req) {
 	if (isRunning) {
 		if (isAdded) {
-			NotifyAdded(currentItem);
-		} 
+			if (currentItem !== NULL) {
+				NotifyAdded(currentItem);
+			}
+		}
 		else {
-			NotifyRemoved(currentItem);
+			if (currentItem !== NULL) {
+				NotifyRemoved(currentItem);
+			}
 		}
 	}
 
@@ -101,7 +105,7 @@ void Stop() {
 void InitDetection() {
 	/* Create the udev object */
 	udev = udev_new();
-	if (!udev) 
+	if (!udev)
 	{
 		printf("Can't create udev\n");
 		return;
@@ -227,7 +231,7 @@ void DeviceRemoved(struct udev_device* dev) {
 		item = new ListResultItem_t();
 		GetProperties(dev, item);
 	}
-	
+
 	currentItem = item;
 	isAdded = false;
 
@@ -271,7 +275,7 @@ void BuildInitialDeviceList() {
 	   which contains the device's path in /sys. */
 	udev_list_entry_foreach(dev_list_entry, devices) {
 		const char *path;
-		
+
 		/* Get the filename of the /sys entry for the device
 		   and create a udev_device object (dev) representing it */
 		path = udev_list_entry_get_name(dev_list_entry);

--- a/src/detection_mac.cpp
+++ b/src/detection_mac.cpp
@@ -365,14 +365,10 @@ void NotifyAsync(uv_work_t* req) {
 void NotifyFinished(uv_work_t* req) {
 	if(isRunning) {
 		if(isAdded) {
-			if(notify_item !== NULL) {
-				NotifyAdded(notify_item);
-			}
+			NotifyAdded(notify_item);
 		}
 		else {
-			if(notify_item !== NULL) {
-				NotifyRemoved(notify_item);
-			}
+			NotifyRemoved(notify_item);
 		}
 	}
 

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -11,7 +11,7 @@
 #include <tchar.h>
 #include <strsafe.h>
 #include <Setupapi.h>
- 
+
 #include "detection.h"
 #include "deviceList.h"
 
@@ -57,14 +57,14 @@ HWND handle;
 DWORD threadId;
 HANDLE threadHandle;
 
-HANDLE deviceChangedRegisteredEvent; 
+HANDLE deviceChangedRegisteredEvent;
 HANDLE deviceChangedSentEvent;
 
 ListResultItem_t* currentDevice;
 bool isAdded;
 bool isRunning = false;
 
-HINSTANCE hinstLib; 
+HINSTANCE hinstLib;
 
 
 typedef BOOL (WINAPI *_SetupDiEnumDeviceInfo) (HDEVINFO DeviceInfoSet, DWORD MemberIndex, PSP_DEVINFO_DATA DeviceInfoData);
@@ -107,12 +107,12 @@ void NotifyAsync(uv_work_t* req) {
 void NotifyFinished(uv_work_t* req) {
 	if (isRunning) {
 		if(isAdded) {
-			if (currentDevice != NULL) {
+			if (currentDevice !== NULL) {
 				NotifyAdded(currentDevice);
 			}
 		}
 		else {
-			if (currentDevice != NULL) {
+			if (currentDevice !== NULL) {
 				NotifyRemoved(currentDevice);
 			}
 		}
@@ -133,18 +133,18 @@ void LoadFunctions() {
 
 	bool success;
 
-	hinstLib = LoadLibrary(LIBRARY_NAME); 
+	hinstLib = LoadLibrary(LIBRARY_NAME);
 
 	if (hinstLib != NULL) {
-		DllSetupDiEnumDeviceInfo = (_SetupDiEnumDeviceInfo) GetProcAddress(hinstLib, "SetupDiEnumDeviceInfo"); 
+		DllSetupDiEnumDeviceInfo = (_SetupDiEnumDeviceInfo) GetProcAddress(hinstLib, "SetupDiEnumDeviceInfo");
 
-		DllSetupDiGetClassDevs = (_SetupDiGetClassDevs) GetProcAddress(hinstLib, "SetupDiGetClassDevsA"); 
+		DllSetupDiGetClassDevs = (_SetupDiGetClassDevs) GetProcAddress(hinstLib, "SetupDiGetClassDevsA");
 
-		DllSetupDiDestroyDeviceInfoList = (_SetupDiDestroyDeviceInfoList) GetProcAddress(hinstLib, "SetupDiDestroyDeviceInfoList"); 
+		DllSetupDiDestroyDeviceInfoList = (_SetupDiDestroyDeviceInfoList) GetProcAddress(hinstLib, "SetupDiDestroyDeviceInfoList");
 
-		DllSetupDiGetDeviceInstanceId = (_SetupDiGetDeviceInstanceId) GetProcAddress(hinstLib, "SetupDiGetDeviceInstanceIdA"); 
+		DllSetupDiGetDeviceInstanceId = (_SetupDiGetDeviceInstanceId) GetProcAddress(hinstLib, "SetupDiGetDeviceInstanceIdA");
 
-		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty) GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA"); 
+		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty) GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA");
 
 		success = (
 			DllSetupDiEnumDeviceInfo != NULL &&
@@ -182,12 +182,12 @@ void InitDetection() {
 
 	BuildInitialDeviceList();
 
-	threadHandle = CreateThread( 
+	threadHandle = CreateThread(
 			NULL,				// default security attributes
-			0,					// use default stack size  
+			0,					// use default stack size
 			ListenerThread,		// thread function name
-			NULL,				// argument to thread function 
-			0,					// use default creation flags 
+			NULL,				// argument to thread function
+			0,					// use default creation flags
 			&threadId
 		);
 
@@ -236,7 +236,7 @@ void extractVidPid(char * buf, ListResultItem_t * item) {
 
 	vidStr = strstr(string, VID_TAG);
 	pidStr = strstr(string, PID_TAG);
-	
+
 	if(vidStr != NULL) {
 		temp = (char*) (vidStr + strlen(VID_TAG));
 		temp[4] = '\0';
@@ -258,11 +258,11 @@ void extractVidPid(char * buf, ListResultItem_t * item) {
 LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	if (msg == WM_DEVICECHANGE) {
 		if ( DBT_DEVICEARRIVAL == wParam || DBT_DEVICEREMOVECOMPLETE == wParam ) {
-			PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;  
-			PDEV_BROADCAST_DEVICEINTERFACE pDevInf;  
+			PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
+			PDEV_BROADCAST_DEVICEINTERFACE pDevInf;
 
 			if(pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE) {
-				pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr; 
+				pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
 				UpdateDevice(pDevInf, wParam, (DBT_DEVICEARRIVAL == wParam) ? DeviceState_Connect : DeviceState_Disconnect);
 			}
 		}
@@ -272,7 +272,7 @@ LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 }
 
 
-DWORD WINAPI ListenerThread( LPVOID lpParam ) { 
+DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 	char className[MAX_THREAD_WINDOW_NAME];
 	_snprintf_s(className, MAX_THREAD_WINDOW_NAME, "ListnerThreadUsbDetection_%d", GetCurrentThreadId());
 
@@ -287,7 +287,7 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 		return 1;
 	}
 
-	
+
 	HWND hwnd = CreateWindowExA(WS_EX_TOPMOST, className, className, 0, 0, 0, 0, 0, NULL, 0, 0, 0);
 	if (!hwnd) {
 		DWORD le = GetLastError();
@@ -319,7 +319,7 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 	}
 
 	return 0;
-} 
+}
 
 
 void BuildInitialDeviceList() {
@@ -349,7 +349,7 @@ void BuildInitialDeviceList() {
 		AddItemToList(buf, item);
 		ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &item->deviceParams);
 	}
-	
+
 	if(pspDevInfoData) {
 		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
 	}
@@ -361,7 +361,7 @@ void BuildInitialDeviceList() {
 
 
 void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* buf, DWORD buffSize, ListResultItem_t* resultItem) {
-	
+
 	DWORD DataT;
 	DWORD nSize;
 	static int dummy = 1;
@@ -372,21 +372,21 @@ void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR
 	// device found
 	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, buffSize, &nSize)) {
 		resultItem->deviceName = buf;
-	} 
-	else if ( DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize)) 
+	}
+	else if ( DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize))
 	{
 		resultItem->deviceName = buf;
-	} 
+	}
 	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, buffSize, &nSize)) {
 		resultItem->manufacturer = buf;
-	} 
+	}
 	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, buffSize, &nSize)) {
 		// Use this to extract VID / PID
 		extractVidPid(buf, resultItem);
-	} 
+	}
 }
 
- 
+
 void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state) {
 	// dbcc_name:
 	// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
@@ -424,7 +424,7 @@ void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceS
 		if(szDevId == buf) {
 
 			WaitForSingleObject(deviceChangedSentEvent, INFINITE);
-			
+
 			DWORD DataT;
 			DWORD nSize;
 			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, MAX_PATH, &nSize);

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -107,14 +107,10 @@ void NotifyAsync(uv_work_t* req) {
 void NotifyFinished(uv_work_t* req) {
 	if (isRunning) {
 		if(isAdded) {
-			if (currentDevice !== NULL) {
-				NotifyAdded(currentDevice);
-			}
+			NotifyAdded(currentDevice);
 		}
 		else {
-			if (currentDevice !== NULL) {
-				NotifyRemoved(currentDevice);
-			}
+			NotifyRemoved(currentDevice);
 		}
 	}
 


### PR DESCRIPTION
We've been using this in an electron app running in Windows. We were getting a crash about 5-10 minutes into launching the app. We've only been able to reproduce it on one PC. Somehow NotifyRemoved in detection.cpp is getting called with a null device and causing a null ptr exception. The PC has a touchscreen that isn't working so it may be that the touchscreen device is continually connecting and disconnecting to create this scenario. 
In any case, this change has fixed the crash for us. 