### PR TITLE
Create prebuilt binaries using `prebuild`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ $ cat .gitignore
 # Can also ignore all directories and files in a directory.
 node_modules/
 build/
+
+# Ignore `prebuild` output
+prebuilds/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,101 @@
+---
+notifications:
+  email: false
+language: cpp
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - build-essential
+    - g++-4.8
+    - g++-4.8-multilib
+    - gcc-multilib
+sudo: true
+
+# Build matrix
+os:
+- linux
+- osx
+env:
+  global:
+  - secure: "CZZYc72Vyft6srihAyJkbBrGg41BclhSn+Y7fjJOhyvAA6ne7WuW83goIY9CGAxBsqhz+HezG4UNmZf0j0UCVBAcFdblItdzW+VbaWCR7+MfrWP+KMVHsaTV81loLO5LwmEl9/I/Tta17KXG1ILcXoWJl96pTf/zO/RnECSBVMgRaIxuiVY7OdzuWvws/DVJEisWbAB3aMUmbo/sN50+jS7LHfRefnPW8MjT6RickDsL6y9fibYoacaUA6vQFwqqvDGBbZLG4fXs25mDQzdlWNsaaBsD0iv4S6IDQU3we5NZOAB5Z9MgZLN5GKei49hkbPOI411M0JmVU3hP2OZHxMCHAnN3crBtr7nmLY8Px3RLzMHw0UBwAr1r4r2GOSezl+yxpwlEhDXaG4ncJ+6KOuyhTk/Asbe/bLJpZnXe5v8mMr9QpMM1MFdBuM0C78baOIk7o+Fi9K/2Sp+I1Zg9qthjHAUGCI+6lPNOcnof4zLSWugBVzPZ1sGxFEIuMCUPWo8QBffiJ5J+sr6yX+r9fpSgd6nCCtkJ05UcwCfBAJyk9BDmt7vGQvLbNKVz3sIeKmti38KiPFaS7ZZHsXe+RPXSpC4IVTgJHwvA8It+Y3PN6pIiBt1NsGJwrYjKo/y02ls2lTFbqK6p8KpLCGbfLbOEDveB4YenH01eIahANhs="
+  matrix:
+  - TRAVIS_NODE_VERSION="4"
+  - TRAVIS_NODE_VERSION="4" ARCH="x86"
+  - TRAVIS_NODE_VERSION="6"
+  - TRAVIS_NODE_VERSION="6" ARCH="x86"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
+matrix:
+  exclude:
+  - os: osx
+    env: TRAVIS_NODE_VERSION="4" ARCH="x86"
+  - os: osx
+    env: TRAVIS_NODE_VERSION="6" ARCH="x86"
+  - os: osx
+    env: BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
+
+cache:
+  directories:
+    - $HOME/.npm/
+    - $HOME/.npm-cache/
+
+before_install:
+
+# download node if testing x86 architecture
+- >
+  if [[ "$ARCH" == "x86" ]]; then
+    EXPANDED_VERSION=$(curl https://semver.io/node/resolve/$TRAVIS_NODE_VERSION);
+    echo "EXPANDED_VERSION =" $EXPANDED_VERSION
+    BASE_URL=https://nodejs.org/dist/v$EXPANDED_VERSION;
+    X86_FILE=node-v$EXPANDED_VERSION-$(node -p "process.platform")-x86;
+    echo "X86_FILE =" $X86_FILE;
+    wget $BASE_URL/$X86_FILE.tar.gz;
+    tar -xf $X86_FILE.tar.gz;
+    nvm deactivate;
+    export PATH=$X86_FILE/bin:$PATH;
+    if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install libudev-dev:i386; fi
+  else
+    nvm install $TRAVIS_NODE_VERSION
+    if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install libudev-dev; fi
+  fi;
+# use g++-4.8 on Linux
+- if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
+- $CXX --version
+
+# upgrade npm if on node 4 as npm2 doesn't like our dev peer deps
+- if [[ $TRAVIS_NODE_VERSION == "4" ]]; then npm install -g npm; fi
+
+# Cleanup the output of npm
+- npm config set progress false
+- npm config set spin false
+
+# print versions
+- uname -a
+- which node; file `which node`
+- node --version
+- node -p 'process.platform + "@" + process.arch'
+- npm --version
+
+# figure out if we should publish
+- PUBLISH_BINARY=false
+- echo $TRAVIS_BRANCH
+- echo `git describe --tags --always HEAD`
+- if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=$BINARY_BUILDER; fi;
+- echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
+
+install:
+# ensure source install works
+- npm install --build-from-source
+
+script:
+# Tests are disabled until we have tests which are suitable for CI and don't require manual interaction.
+# - npm test
+- echo "Skipping tests on CI, as they currently require manual interaction."
+
+# if publishing, do it
+- >
+  if [[ $PUBLISH_BINARY == true ]]; then
+    npm run prebuild;
+  fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - g++-4.8
     - g++-4.8-multilib
     - gcc-multilib
-sudo: true
+dist: trusty
+sudo: required
 
 # Build matrix
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@
 notifications:
   email: false
 language: cpp
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8-multilib
-    - gcc-multilib
 dist: trusty
 sudo: required
 
@@ -54,17 +47,12 @@ before_install:
     tar -xf $X86_FILE.tar.gz;
     nvm deactivate;
     export PATH=$X86_FILE/bin:$PATH;
-    if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install libudev-dev:i386; fi
+    if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install libudev-dev:i386 g++-multilib; fi
   else
     nvm install $TRAVIS_NODE_VERSION
     if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install libudev-dev; fi
   fi;
-# use g++-4.8 on Linux
-- if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
 - $CXX --version
-
-# upgrade npm if on node 4 as npm2 doesn't like our dev peer deps
-- if [[ $TRAVIS_NODE_VERSION == "4" ]]; then npm install -g npm; fi
 
 # Cleanup the output of npm
 - npm config set progress false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+environment:
+  nodejs_version: "8"
+  prebuild_upload:
+    secure: NnjZSO7TY7D2bVC03erJ8zeetFAVLAC+IcPg2n7GEaTdciyzt463GrdNWSdpEuqT
+
+  matrix:
+  - nodejs_version: "4"
+  - nodejs_version: "6"
+  - binary_builder: "true"
+    nodejs_version: "8"
+
+platform:
+  - x86
+  - x64
+
+cache:
+  - '%APPDATA%\npm'
+  - '%APPDATA%\npm-cache'
+
+install:
+- ps: Install-Product node $env:nodejs_version $env:platform
+- ps: >
+    @{
+      "nodejs_version" = $env:nodejs_version
+      "platform" = $env:platform
+      "node binary version" = $(node -v)
+      "node platform@arch" = $(node -p 'process.platform + process.arch')
+      "npm version" = $(npm -v)
+      "APPVEYOR_REPO_COMMIT_MESSAGE" = $env:APPVEYOR_REPO_COMMIT_MESSAGE
+      "git latest tag" = "$(git describe --tags --always HEAD)"
+      "appveyor_repo_tag" = $env:appveyor_repo_tag
+    } | Out-String | Write-Host;
+- npm install
+
+# Check if we're building the latest tag, if so
+# then we publish the binaries if tests pass.
+- ps: >
+    if ($env:appveyor_repo_tag -match "true" -and ("$(git describe --tags --always HEAD)" -eq $env:appveyor_repo_tag_name)) {
+      $env:publish_binary = $env:binary_builder;
+    }
+    if ($env:publish_binary -eq "true") {
+      "We're publishing a binary!" | Write-Host
+    } else {
+      "We're not publishing a binary" | Write-Host
+    }
+    true;
+
+build_script:
+- npm install --build-from-source
+
+test_script:
+# Tests are disabled until we have tests which are suitable for CI and don't require manual interaction.
+# - npm test
+- echo "Skipping tests on CI, as they currently require manual interaction."
+
+- ps: >
+    if ($env:publish_binary -eq "true") {
+      npm run prebuild
+    }
+    true;
+
+deploy: OFF

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
   "scripts": {
     "test": "mocha --timeout 10000",
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild --all && prebuild --all --runtime electron",
-    "upload-prebuilds": "prebuild --upload-all"
+    "prebuild": "prebuild --all --strip --verbose"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/MadLittleMods/node-usb-detection.git"
+    "url": "git://github.com/lange/node-usb-detection.git"
   },
   "keywords": [
     "usb",
@@ -27,13 +26,13 @@
     "unplug",
     "notification"
   ],
-  "homepage": "https://github.com/MadLittleMods/node-usb-detection",
+  "homepage": "https://github.com/lange/node-usb-detection",
   "bugs": {
-    "url": "https://github.com/MadLittleMods/node-usb-detection/issues"
+    "url": "https://github.com/lange/node-usb-detection/issues"
   },
   "license": {
     "type": "MIT",
-    "url": "https://raw.github.com/MadLittleMods/node-usb-detection/master/licence"
+    "url": "https://raw.github.com/lange/node-usb-detection/master/licence"
   },
   "dependencies": {
     "bindings": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "gypfile": true,
   "scripts": {
     "test": "mocha --timeout 10000",
-    "postinstall": "node-gyp rebuild"
+    "install": "prebuild-install || node-gyp rebuild",
+    "prebuild": "prebuild --all && prebuild --all --runtime electron",
+    "upload-prebuilds": "prebuild --upload-all"
   },
   "repository": {
     "type": "git",
@@ -37,12 +39,14 @@
     "bindings": "1.1.0",
     "bluebird": "^2.9.27",
     "eventemitter2": ">=0.4.11",
-    "nan": "^2.2.0"
+    "nan": "^2.2.0",
+    "prebuild-install": "^2.3.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "chalk": "^1.0.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "prebuild": "^6.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/lange/node-usb-detection.git"
+    "url": "git://github.com/MadLittleMods/node-usb-detection.git"
   },
   "keywords": [
     "usb",
@@ -26,13 +26,13 @@
     "unplug",
     "notification"
   ],
-  "homepage": "https://github.com/lange/node-usb-detection",
+  "homepage": "https://github.com/MadLittleMods/node-usb-detection",
   "bugs": {
-    "url": "https://github.com/lange/node-usb-detection/issues"
+    "url": "https://github.com/MadLittleMods/node-usb-detection/issues"
   },
   "license": {
     "type": "MIT",
-    "url": "https://raw.github.com/lange/node-usb-detection/master/licence"
+    "url": "https://raw.github.com/MadLittleMods/node-usb-detection/master/licence"
   },
   "dependencies": {
     "bindings": "1.1.0",


### PR DESCRIPTION
Closes #40.

This PR should provide almost everything needed to immediately start getting pre-built binaries automatically created and uploaded to GitHub for the following platforms:

- [x] Windows x86
- [x] Windows x64
- [x] Linux x86
- [x] Linux x64
- [x] macOS x64

Before merging, you'll want to set up this project on both AppVeyor and TravisCI. This should be just a few mouse clicks, all you're doing is telling these services that yes, you would like to build this project. You don't need to do any configuration at this time.

Once that's done, you'll need to replace my encrypted GitHub token (the `prebuild_upload` environment variable) with your own:

1. Follow the steps outlined in the [prebuild docs](https://github.com/prebuild/prebuild#create-github-token) for creating a GitHub token with the appropriate scope permissions.
2. Use the [AppVeyor "Encrypt Data" page](https://ci.appveyor.com/tools/encrypt) to encrypt your token. Then, paste it over my encrypted token in line 4 of `appveyor.yml`.
3. [Install the TravisCI CLI.](https://github.com/travis-ci/travis.rb#installation)
4. From your local `node-usb-detection` directory, run the following command to get your encrypted `prebuild_upload` env var with your token:

    ```bash
    travis encrypt prebuild_upload=YOUR_GITHUB_TOKEN_HERE
    ```
5. Copy the resulting output and paste it over mine in line 22 of `.travis.yml`.
6. Commit/push your changes, then merge this PR! :tada: If I've done everything right, tagged commits will trigger a build, and automatically publish their artifacts to the GitHub release. The release will also be created if it does not already exist.

Caveats:
- Travis' OSX build infrastructure is pretty overwhelmed at this point. On bad days it can take upwards of 5 hours for an OSX build to start. At night it settles down and you can usually get your build started immediately. You can look at the graphs on https://www.traviscistatus.com/ to get a feel for the patterns of when their infrastructure is completely slammed.

Credits:
- I used pretty much all of the CI configs from [`node-serialport`](https://github.com/node-serialport/node-serialport) as a base. I made very few modifications to them.