### PR TITLE
Remove install hook to prevent hanging - Prepare 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.4.2 - 2017-11-11
+
+ - Remove npm `install` hook to prevent hanging the install process caused by `prebuild-install` verify require and our side-effects.
+    - Thanks to [@Lange](https://github.com/Lange) for [figuring out the root cause](https://github.com/MadLittleMods/node-usb-detection/pull/47#issuecomment-343714022).
+
 ## v1.4.1 - 2017-11-11
 
  - Add check for null before notifying of addition/removal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/usb-detection.svg)](http://badge.fury.io/js/usb-detection)
+[![npm version](https://badge.fury.io/js/usb-detection.svg)](http://badge.fury.io/js/usb-detection) [![Gitter](https://badges.gitter.im/MadLittleMods/node-usb-detection.svg)](https://gitter.im/MadLittleMods/node-usb-detection?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
 # usb-detection

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "gypfile": true,
   "scripts": {
     "test": "mocha --timeout 10000",
-    "install": "prebuild-install || node-gyp rebuild",
     "prebuild": "prebuild --all --strip --verbose"
   },
   "repository": {


### PR DESCRIPTION
 - Remove install hook to prevent hanging when installing.
    - Thanks to @Lange for figuring out the root cause speedily, https://github.com/MadLittleMods/node-usb-detection/pull/47#issuecomment-343714022
 - Prepare `usb-detect@1.4.2`