### PR TITLE
Remove side-effects and instead use startMonitoring()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
+## *v2.x upcoming*
+
+ - Remove side-effects when you `require('usb-detection')` so the process won't hang from just requiring.
+   Now requires an explicit call to `usbDetect.startMonitoring()` to begin listening to USB add/remove/change events.
+ - Add npm `install` hook that will use our prebuilt binaries instead of having to compile from source with node-gyp.
+
+
 ## v1.4.2 - 2017-11-11
 
  - Remove npm `install` hook to prevent hanging the install process caused by `prebuild-install` verify require and our side-effects.
     - Thanks to [@Lange](https://github.com/Lange) for [figuring out the root cause](https://github.com/MadLittleMods/node-usb-detection/pull/47#issuecomment-343714022).
+
 
 ## v1.4.1 - 2017-11-11
 

--- a/README.md
+++ b/README.md
@@ -15,41 +15,13 @@
 npm install usb-detection
 ```
 
-This assumes you also have everything on your system necessary to compile ANY native module for Node.js. This may not be the case, though, so please ensure the following requirements are satisfied before filing an issue about "Does not install". For all operating systems, please ensure you have Python 2.x installed AND not 3.0, [node-gyp](https://github.com/TooTallNate/node-gyp) (what we use to compile) requires Python 2.x.
-
-### Windows:
-
- - Visual Studio 2013/2015 Community
- - Visual Studio 2010
- - Visual C++ Build Tools 2015: https://github.com/nodejs/node-gyp/issues/629#issuecomment-153196245
-
-If you are having problems building, [please read this](https://github.com/TooTallNate/node-gyp/issues/44).
-
-### Mac OS X:
-
-Ensure that you have at a minimum, the xCode Command Line Tools installed appropriate for your system configuration. If you recently upgraded your OS, it probably removed your installation of Command Line Tools, please verify before submitting a ticket.
-
-### Linux:
-
-You know what you need for you system, basically your appropriate analog of build-essential. Keep rocking!
-
-To compile and install native addons from npm you may also need to install build tools *([source](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions))*:
-
-```
-sudo apt-get install -y build-essential
-```
-
-Also install libudev:
-
-```
-sudo apt-get install libudev-dev
-```
-
 
 # Usage
 
 ```js
 var usbDetect = require('usb-detection');
+
+usbDetect.startMonitoring();
 
 // Detect add/insert
 usbDetect.on('add', function(device) { console.log('add', device); });
@@ -77,7 +49,17 @@ usbDetect.find().then(function(devices) { console.log(devices); }).catch(functio
 
 # API
 
-## `on(eventName, callback)`
+## `usbDetect.startMonitoring()`
+
+Start listening for USB add/remove/change events. This will cause the Node.js process to stay open until you call `usbDetect.stopMonitoring()` (see below).
+
+
+## `usbDetect.stopMonitoring()`
+
+Stop listening for USB add/remove/change events. This will also allow the Node.js process to exit.
+
+
+## `usbDetect.on(eventName, callback)`
 
  - `eventName`
  	 - `add`: also aliased as `insert`
@@ -95,6 +77,8 @@ usbDetect.find().then(function(devices) { console.log(devices); }).catch(functio
 
 ```js
 var usbDetect = require('usb-detection');
+usbDetect.startMonitoring();
+
 usbDetect.on('add', function(device) {
 	console.log(device);
 });
@@ -113,7 +97,7 @@ usbDetect.on('add', function(device) {
 ```
 
 
-## `find(vid, pid, callback)`
+## `usbDetect.find(vid, pid, callback)`
 
 **Note:** All `find` calls return a promise even with the node-style callback flavors.
 
@@ -134,6 +118,8 @@ Parameters:
 
 ```js
 var usbDetect = require('usb-detection');
+usbDetect.startMonitoring();
+
 usbDetect.find(function(err, devices) {
 	console.log(devices, err);
 });
@@ -175,11 +161,44 @@ usbDetect.find(function(err, devices) {
 var usbDetect = require('usb-detection');
 
 // Do some detection
+usbDetect.startMonitoring();
 
 // After this call, the process will be able to quit
 usbDetect.stopMonitoring();
 ```
 
+
+# Development (compile from source)
+
+This assumes you also have everything on your system necessary to compile ANY native module for Node.js. This may not be the case, though, so please ensure the following requirements are satisfied before filing an issue about "Does not install". For all operating systems, please ensure you have Python 2.x installed AND not 3.0, [node-gyp](https://github.com/TooTallNate/node-gyp) (what we use to compile) requires Python 2.x.
+
+### Windows:
+
+ - Visual Studio 2013/2015 Community
+ - Visual Studio 2010
+ - Visual C++ Build Tools 2015: https://github.com/nodejs/node-gyp/issues/629#issuecomment-153196245
+
+If you are having problems building, [please read this](https://github.com/TooTallNate/node-gyp/issues/44).
+
+### Mac OS X:
+
+Ensure that you have at a minimum, the xCode Command Line Tools installed appropriate for your system configuration. If you recently upgraded your OS, it probably removed your installation of Command Line Tools, please verify before submitting a ticket.
+
+### Linux:
+
+You know what you need for you system, basically your appropriate analog of build-essential. Keep rocking!
+
+To compile and install native addons from npm you may also need to install build tools *([source](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions))*:
+
+```
+sudo apt-get install -y build-essential
+```
+
+Also install libudev:
+
+```
+sudo apt-get install libudev-dev
+```
 
 
 # Testing

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ if (global[index.name] && global[index.name].version === index.version) {
 		detector.emit('change', device);
 	});
 
-	var started = true;
+	var started = false;
 
 	detector.startMonitoring = function() {
 		if(started) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "gypfile": true,
   "scripts": {
     "test": "mocha --timeout 10000",
-    "prebuild": "prebuild --all --strip --verbose"
+    "install": "prebuild-install || node-gyp rebuild",
+    "prebuild": "prebuild --all --strip --verbose",
+    "rebuild": "node-gyp rebuild"
   },
   "repository": {
     "type": "git",

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -125,8 +125,6 @@ void InitDetection() {
 	uv_queue_work(uv_default_loop(), req, NotifyAsync, (uv_after_work_cb)NotifyFinished);
 
 	pthread_create(&thread, NULL, ThreadFunc, NULL);
-
-	Start();
 }
 
 

--- a/src/detection_mac.cpp
+++ b/src/detection_mac.cpp
@@ -450,8 +450,6 @@ void InitDetection() {
 
 	uv_work_t* req = new uv_work_t();
 	uv_queue_work(uv_default_loop(), req, NotifyAsync, (uv_after_work_cb)NotifyFinished);
-
-	Start();
 }
 
 void EIO_Find(uv_work_t* req) {

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -189,8 +189,6 @@ void InitDetection() {
 
 	uv_work_t* req = new uv_work_t();
 	uv_queue_work(uv_default_loop(), req, NotifyAsync, (uv_after_work_cb)NotifyFinished);
-
-	Start();
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,18 +11,8 @@ var chalk = require('chalk');
 // The plugin to test
 var usbDetect = require('../');
 
-
-function once(eventName) {
-	return new Promise(function(resolve) {
-		usbDetect.on(eventName, function(device) {
-			resolve(device);
-		});
-	});
-}
-
-
 // We just look at the keys of this device object
-var deviceObjectFixture = {
+var DEVICE_OBJECT_FIXTURE = {
 	locationId: 0,
 	vendorId: 5824,
 	productId: 1155,
@@ -32,14 +22,28 @@ var deviceObjectFixture = {
 	deviceAddress: 11
 };
 
+function once(eventName) {
+	return new Promise(function(resolve) {
+		usbDetect.on(eventName, function(device) {
+			resolve(device);
+		});
+	});
+}
 
+function testDeviceShape(device) {
+	expect(device)
+		.to.have.all.keys(DEVICE_OBJECT_FIXTURE)
+		.that.is.an('object');
+}
 
 describe('usb-detection', function() {
-	var testDeviceShape = function(device) {
-		expect(device)
-			.to.have.all.keys(deviceObjectFixture)
-			.that.is.an('object');
-	};
+	before(function() {
+		usbDetect.startMonitoring();
+	});
+
+	after(function() {
+		usbDetect.stopMonitoring();
+	});
 
 	describe('`.find`', function() {
 
@@ -97,11 +101,4 @@ describe('usb-detection', function() {
 				});
 		});
 	});
-
-
-	after(function() {
-		// After this call, the process will be able to quit
-		usbDetect.stopMonitoring();
-	});
-
 });


### PR DESCRIPTION
 - Remove side-effects and instead use `usbDetect.startMonitoring()`
 - Re-introduce npm `install` hook to use prebuilt binaries

 ### Todo

 - [x] Test on Windows (10)
 - [x] Test on macOS (10.12.6)
 - [x] Test on Linux (Ubuntu 16.04)

---

Spawned out of discussion here, https://github.com/MadLittleMods/node-usb-detection/pull/47#issuecomment-343714183, where the install was hanging because `prebuild-install` in our npm `install` hook does a `require` to verify things are working and we have side-effects in v1.