### PR TITLE
Extract Serial Number from Device Instance ID/Path on Windows.

### DIFF
--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -72,6 +72,8 @@ typedef HDEVINFO (WINAPI *_SetupDiGetClassDevs) (const GUID *ClassGuid, PCTSTR E
 typedef BOOL (WINAPI *_SetupDiDestroyDeviceInfoList) (HDEVINFO DeviceInfoSet);
 typedef BOOL (WINAPI *_SetupDiGetDeviceInstanceId) (HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, PTSTR DeviceInstanceId, DWORD DeviceInstanceIdSize, PDWORD RequiredSize);
 typedef BOOL (WINAPI *_SetupDiGetDeviceRegistryProperty) (HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, DWORD Property, PDWORD PropertyRegDataType, PBYTE PropertyBuffer, DWORD PropertyBufferSize, PDWORD RequiredSize);
+typedef BOOL (WINAPI *_SetupDiEnumDeviceInterfaces) (HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, const GUID *InterfaceClassGuid, DWORD MemberIndex, PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData);
+typedef BOOL (WINAPI *_SetupDiGetDeviceInterfaceDetail) (HDEVINFO DeviceInfoSet, PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData, PSP_DEVICE_INTERFACE_DETAIL_DATA DeviceInterfaceDetailData, DWORD DeviceInterfaceDetailDataSize, PDWORD RequiredSize, PSP_DEVINFO_DATA DeviceInfoData);
 
 
 _SetupDiEnumDeviceInfo DllSetupDiEnumDeviceInfo;
@@ -79,12 +81,15 @@ _SetupDiGetClassDevs DllSetupDiGetClassDevs;
 _SetupDiDestroyDeviceInfoList DllSetupDiDestroyDeviceInfoList;
 _SetupDiGetDeviceInstanceId DllSetupDiGetDeviceInstanceId;
 _SetupDiGetDeviceRegistryProperty DllSetupDiGetDeviceRegistryProperty;
+_SetupDiEnumDeviceInterfaces DllSetupDiEnumDeviceInterfaces;
+_SetupDiGetDeviceInterfaceDetail DllSetupDiGetDeviceInterfaceDetail;
 
 
 /**********************************
  * Local Helper Functions protoypes
  **********************************/
-void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state);
+void HandleDeviceConnect(PDEV_BROADCAST_DEVICEINTERFACE pDevInf);
+void HandleDeviceDisconnect(PDEV_BROADCAST_DEVICEINTERFACE pDevInf);
 DWORD WINAPI ListenerThread(LPVOID lpParam);
 
 void BuildInitialDeviceList();
@@ -92,7 +97,7 @@ void BuildInitialDeviceList();
 void NotifyAsync(uv_work_t* req);
 void NotifyFinished(uv_work_t* req);
 
-void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* buf, DWORD buffSize, ListResultItem_t* resultItem);
+void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* devicePath, ListResultItem_t* resultItem);
 bool CheckValidity(ListResultItem_t* item);
 
 
@@ -142,12 +147,18 @@ void LoadFunctions() {
 
 		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty) GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA");
 
+		DllSetupDiEnumDeviceInterfaces = (_SetupDiEnumDeviceInterfaces) GetProcAddress(hinstLib, "SetupDiEnumDeviceInterfaces");
+
+		DllSetupDiGetDeviceInterfaceDetail = (_SetupDiGetDeviceInterfaceDetail) GetProcAddress(hinstLib, "SetupDiGetDeviceInterfaceDetailA");
+
 		success = (
 			DllSetupDiEnumDeviceInfo != NULL &&
 			DllSetupDiGetClassDevs != NULL &&
 			DllSetupDiDestroyDeviceInfoList != NULL &&
 			DllSetupDiGetDeviceInstanceId != NULL &&
-			DllSetupDiGetDeviceRegistryProperty != NULL
+			DllSetupDiGetDeviceRegistryProperty != NULL &&
+			DllSetupDiEnumDeviceInterfaces != NULL &&
+			DllSetupDiGetDeviceInterfaceDetail != NULL
 		);
 	}
 	else {
@@ -203,49 +214,21 @@ void EIO_Find(uv_work_t* req) {
 /**********************************
  * Local Functions
  **********************************/
-void ToUpper(char * buf) {
-	char* c = buf;
-	while (*c != '\0') {
-		*c = toupper((unsigned char)*c);
-		c++;
-	}
-}
 
+void ExtractDetails(TCHAR* devicePath, ListResultItem_t* item) {
+	// expected format:
+	// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
+	CString dpcs = devicePath + 4;
 
-void extractVidPid(char * buf, ListResultItem_t * item) {
-	if(buf == NULL) {
-		return;
-	}
+	CString temp = devicePath;
+	temp = temp.Left(temp.ReverseFind(_T('#')));
+	temp = temp.Mid(temp.ReverseFind(_T('#')) + 1);
+	item->serialNumber = temp;
 
-	ToUpper(buf);
-
-	char* string;
-	char* temp;
-	char* pidStr, *vidStr;
-	int vid = 0;
-	int pid = 0;
-
-	string = new char[strlen(buf) + 1];
-	memcpy(string, buf, strlen(buf) + 1);
-
-	vidStr = strstr(string, VID_TAG);
-	pidStr = strstr(string, PID_TAG);
-
-	if(vidStr != NULL) {
-		temp = (char*) (vidStr + strlen(VID_TAG));
-		temp[4] = '\0';
-		vid = strtol (temp, NULL, 16);
-	}
-
-	if(pidStr != NULL) {
-		temp = (char*) (pidStr + strlen(PID_TAG));
-		temp[4] = '\0';
-		pid = strtol (temp, NULL, 16);
-	}
-	item->vendorId = vid;
-	item->productId = pid;
-
-	delete string;
+	temp = devicePath;
+	temp.MakeUpper();
+	item->vendorId = strtol(temp.Mid(temp.Find(VID_TAG) + strlen(VID_TAG), 4), NULL, 16);
+	item->productId = strtol(temp.Mid(temp.Find(PID_TAG) + strlen(PID_TAG), 4), NULL, 16);
 }
 
 
@@ -257,7 +240,11 @@ LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
 			if(pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE) {
 				pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
-				UpdateDevice(pDevInf, wParam, (DBT_DEVICEARRIVAL == wParam) ? DeviceState_Connect : DeviceState_Disconnect);
+				if (DBT_DEVICEARRIVAL == wParam) {
+					HandleDeviceConnect(pDevInf);
+				} else {
+					HandleDeviceDisconnect(pDevInf);
+				}
 			}
 		}
 	}
@@ -315,11 +302,42 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 	return 0;
 }
 
+BOOL GetDeviceDetails(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, int index, PSP_DEVICE_INTERFACE_DETAIL_DATA* pspDeviceIntDetail) {
+	SP_DEVICE_INTERFACE_DATA spDevIntData;
+	spDevIntData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+
+	if (!DllSetupDiEnumDeviceInterfaces(hDevInfo, NULL, &GUID_DEVINTERFACE_USB_DEVICE, index, &spDevIntData)) {
+		return false;
+	}
+
+	DWORD dwSize = 0;
+	if (DllSetupDiGetDeviceInterfaceDetail(hDevInfo, &spDevIntData, NULL, 0, &dwSize, NULL)) {
+		return false;
+	}
+
+	if (ERROR_INSUFFICIENT_BUFFER != GetLastError()) {
+		return false;
+	}
+
+	*pspDeviceIntDetail = (PSP_DEVICE_INTERFACE_DETAIL_DATA) malloc(dwSize);
+	if (NULL == pspDeviceIntDetail) {
+		return false;
+	}
+	(*pspDeviceIntDetail)->cbSize = sizeof(PSP_DEVICE_INTERFACE_DETAIL_DATA);
+
+	if (!DllSetupDiGetDeviceInterfaceDetail(hDevInfo, &spDevIntData, *pspDeviceIntDetail, dwSize, NULL, NULL)) {
+		free(pspDeviceIntDetail);
+		pspDeviceIntDetail = NULL;
+		return false;
+	}
+	return true;
+}
+
 
 void BuildInitialDeviceList() {
 	TCHAR buf[MAX_PATH];
-	DWORD dwFlag = (DIGCF_ALLCLASSES | DIGCF_PRESENT);
-	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, "USB", NULL, dwFlag);
+	DWORD dwFlag = (DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(&GUID_DEVINTERFACE_USB_DEVICE, NULL, NULL, dwFlag);
 
 	if(INVALID_HANDLE_VALUE == hDevInfo) {
 		return;
@@ -328,20 +346,32 @@ void BuildInitialDeviceList() {
 	SP_DEVINFO_DATA* pspDevInfoData = (SP_DEVINFO_DATA*) HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
 	pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
 	for(int i=0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++) {
-		DWORD nSize=0 ;
-
-		if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize)) {
+		if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), NULL)) {
 			break;
 		}
 
-		DeviceItem_t* item = new DeviceItem_t();
-		item->deviceState = DeviceState_Connect;
+		PSP_DEVICE_INTERFACE_DETAIL_DATA pspDeviceIntDetail = NULL;
+		if (!GetDeviceDetails(hDevInfo, pspDevInfoData, i, &pspDeviceIntDetail)) {
+			continue;
+		}
 
-		DWORD DataT;
-		DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+		// Make sure we can actually talk to this device before adding
+		// it to the list of connected devices.
+		HANDLE devHandle = CreateFile(pspDeviceIntDetail->DevicePath,
+									GENERIC_READ | GENERIC_WRITE,
+									FILE_SHARE_READ | FILE_SHARE_WRITE,
+									NULL, OPEN_EXISTING,
+									FILE_FLAG_OVERLAPPED, NULL);
+		if (INVALID_HANDLE_VALUE != devHandle) {
+			CloseHandle(devHandle);
 
-		AddItemToList(buf, item);
-		ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &item->deviceParams);
+			DeviceItem_t* item = new DeviceItem_t();
+			item->deviceState = DeviceState_Connect;
+
+			ExtractDeviceInfo(hDevInfo, pspDevInfoData, pspDeviceIntDetail->DevicePath, &item->deviceParams);
+			AddItemToList(buf, item);
+		}
+		free(pspDeviceIntDetail);
 	}
 
 	if(pspDevInfoData) {
@@ -354,8 +384,9 @@ void BuildInitialDeviceList() {
 }
 
 
-void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* buf, DWORD buffSize, ListResultItem_t* resultItem) {
+void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* devicePath, ListResultItem_t* resultItem) {
 
+	TCHAR buf[MAX_PATH];
 	DWORD DataT;
 	DWORD nSize;
 	static int dummy = 1;
@@ -364,94 +395,48 @@ void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR
 	resultItem->deviceAddress = dummy++;
 
 	// device found
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, buffSize, &nSize)) {
+	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, MAX_PATH, &nSize)) {
 		resultItem->deviceName = buf;
 	}
-	else if ( DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize))
+	else if ( DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, MAX_PATH, &nSize))
 	{
 		resultItem->deviceName = buf;
 	}
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, buffSize, &nSize)) {
+	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, MAX_PATH, &nSize)) {
 		resultItem->manufacturer = buf;
 	}
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, buffSize, &nSize)) {
-		// Use this to extract VID / PID
-		extractVidPid(buf, resultItem);
-	}
+	ExtractDetails(devicePath, resultItem);
 }
 
-
-void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state) {
-	// dbcc_name:
-	// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
-	// convert to
-	// USB\Vid_04e8&Pid_503b\0002F9A9828E0F06
-	CString szDevId = pDevInf->dbcc_name+4;
-	int idx = szDevId.ReverseFind(_T('#'));
-
-	szDevId.Truncate(idx);
-	szDevId.Replace(_T('#'), _T('\\'));
-	szDevId.MakeUpper();
-
-	CString szClass;
-	idx = szDevId.Find(_T('\\'));
-	szClass = szDevId.Left(idx);
-
-	// if we are adding device, we only need present devices
-	// otherwise, we need all devices
-	DWORD dwFlag = DBT_DEVICEARRIVAL != wParam ? DIGCF_ALLCLASSES : (DIGCF_ALLCLASSES | DIGCF_PRESENT);
-	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, szClass, NULL, dwFlag);
-	if(INVALID_HANDLE_VALUE == hDevInfo) {
+void HandleDeviceConnect(PDEV_BROADCAST_DEVICEINTERFACE pDevInf) {
+	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(&GUID_DEVINTERFACE_USB_DEVICE, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+	if (INVALID_HANDLE_VALUE == hDevInfo) {
 		return;
 	}
 
 	SP_DEVINFO_DATA* pspDevInfoData = (SP_DEVINFO_DATA*) HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
 	pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
 	for(int i=0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++) {
-		DWORD nSize=0 ;
-		TCHAR buf[MAX_PATH];
-
-		if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize)) {
-			break;
+		PSP_DEVICE_INTERFACE_DETAIL_DATA pspDeviceIntDetail = NULL;
+		if (!GetDeviceDetails(hDevInfo, pspDevInfoData, i, &pspDeviceIntDetail)) {
+			continue;
 		}
 
-		if(szDevId == buf) {
+		if (0 == _strnicmp(pDevInf->dbcc_name, pspDeviceIntDetail->DevicePath, strlen(pDevInf->dbcc_name))) {
+			TCHAR buf[MAX_PATH];
+			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), NULL)) {
+				break;
+			}
 
 			WaitForSingleObject(deviceChangedSentEvent, INFINITE);
 
-			DWORD DataT;
-			DWORD nSize;
-			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+			DeviceItem_t* device = new DeviceItem_t();
 
-			if(state == DeviceState_Connect) {
-				DeviceItem_t* device = new DeviceItem_t();
+			ExtractDeviceInfo(hDevInfo, pspDevInfoData, pDevInf->dbcc_name, &device->deviceParams);
+			AddItemToList(buf, device);
 
-				AddItemToList(buf, device);
-				ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &device->deviceParams);
-
-				currentDevice = &device->deviceParams;
-				isAdded = true;
-			}
-			else {
-
-				ListResultItem_t* item = NULL;
-				if(IsItemAlreadyStored(buf)) {
-					DeviceItem_t* deviceItem = GetItemFromList(buf);
-					if(deviceItem)
-					{
-						item = CopyElement(&deviceItem->deviceParams);
-					}
-					RemoveItemFromList(deviceItem);
-					delete deviceItem;
-				}
-
-				if(item == NULL) {
-					item = new ListResultItem_t();
-					ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, item);
-				}
-				currentDevice = item;
-				isAdded = false;
-			}
+			currentDevice = &device->deviceParams;
+			isAdded = true;
 
 			break;
 		}
@@ -461,7 +446,60 @@ void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceS
 		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
 	}
 
-	if(hDevInfo) {
+	if (hDevInfo) {
+		DllSetupDiDestroyDeviceInfoList(hDevInfo);
+	}
+
+	SetEvent(deviceChangedRegisteredEvent);
+}
+
+void HandleDeviceDisconnect(PDEV_BROADCAST_DEVICEINTERFACE pDevInf) {
+	// dbcc_name:
+	// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
+	// convert to
+	// USB\Vid_04e8&Pid_503b\0002F9A9828E0F06
+	CString szDevId = pDevInf->dbcc_name + 4;
+	szDevId.Truncate(szDevId.ReverseFind(_T('#')));
+	szDevId.Replace(_T('#'), _T('\\'));
+
+	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(&GUID_DEVINTERFACE_USB_DEVICE, NULL, NULL, DIGCF_ALLCLASSES);
+	if (INVALID_HANDLE_VALUE == hDevInfo) {
+		return;
+	}
+
+	SP_DEVINFO_DATA* pspDevInfoData = (SP_DEVINFO_DATA*) HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
+	pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
+	for(int i=0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++) {
+		TCHAR buf[MAX_PATH];
+		if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), NULL)) {
+			break;
+		}
+
+		if (0 == _strnicmp(szDevId, buf, strlen(szDevId))) {
+			ListResultItem_t* item = NULL;
+			if (IsItemAlreadyStored(buf)) {
+				DeviceItem_t* deviceItem = GetItemFromList(buf);
+				if (deviceItem) {
+					item = CopyElement(&deviceItem->deviceParams);
+				}
+				RemoveItemFromList(deviceItem);
+				delete deviceItem;
+			}
+
+			if (item == NULL) {
+				item = new ListResultItem_t();
+				ExtractDeviceInfo(hDevInfo, pspDevInfoData, pDevInf->dbcc_name, item);
+			}
+			currentDevice = item;
+			isAdded = false;
+		}
+	}
+
+	if (pspDevInfoData) {
+		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
+	}
+
+	if (hDevInfo) {
 		DllSetupDiDestroyDeviceInfoList(hDevInfo);
 	}
 


### PR DESCRIPTION
Fix https://github.com/MadLittleMods/node-usb-detection/issues/36

This is a quick patch that (hopefully completely) resolves extracting the serial number from USB devices on Windows.

I've tested it with the few devices I have on hand and everything seems to work.