### PR TITLE
Change Device Key to SPDRP_LOCATION_INFORMATION

### DIFF
--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -382,7 +382,7 @@ void BuildInitialDeviceList() {
 		item->deviceState = DeviceState_Connect;
 
 		DWORD DataT;
-		DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+		DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
 
 		AddItemToList(buf, item);
 		ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &item->deviceParams);
@@ -464,7 +464,7 @@ void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceS
 
 			DWORD DataT;
 			DWORD nSize;
-			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
 
 			if(state == DeviceState_Connect) {
 				DeviceItem_t* device = new DeviceItem_t();

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -360,8 +360,7 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 }
 
 
-void BuildInitialDeviceList() {
-	TCHAR buf[MAX_PATH];
+void BuildInitialDeviceList() {	
 	DWORD dwFlag = (DIGCF_ALLCLASSES | DIGCF_PRESENT);
 	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, "USB", NULL, dwFlag);
 
@@ -373,6 +372,7 @@ void BuildInitialDeviceList() {
 	pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
 	for(int i=0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++) {
 		DWORD nSize=0 ;
+		TCHAR buf[MAX_PATH];
 
 		if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize)) {
 			break;
@@ -383,6 +383,7 @@ void BuildInitialDeviceList() {
 
 		DWORD DataT;
 		DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+		DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
 
 		AddItemToList(buf, item);
 		ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &item->deviceParams);
@@ -465,6 +466,7 @@ void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceS
 			DWORD DataT;
 			DWORD nSize;
 			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+  		        DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
 
 			if(state == DeviceState_Connect) {
 				DeviceItem_t* device = new DeviceItem_t();


### PR DESCRIPTION
In AddItemToList function we are using `SPDRP_HARDWAREID` as dictionary key.
This is a problem because if you plug 2 same devices this will overwrite & we will see only 1 device.
If we use `SPDRP_LOCATION_INFORMATION` as key it will be OK.