### PR TITLE
Add note about .find requiring .startMonitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ usbDetect.startMonitoring();
 usbDetect.stopMonitoring();
 ```
 
-### `.find()` always returns the same list of devices, even after removal.
+### `usbDetect.find()` always returns the same list of devices, even after removal.
 
-Make sure you call `startMonitoring()` before any calls to `.find()`.
+Make sure you call `usbDetect.startMonitoring()` before any calls to `usbDetect.find()`.
 
 # Development (compile from source)
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ usbDetect.startMonitoring();
 usbDetect.stopMonitoring();
 ```
 
+### `.find()` always returns the same list of devices, even after removal.
+
+Make sure you call `startMonitoring()` before any calls to `.find()`.
 
 # Development (compile from source)
 


### PR DESCRIPTION
Fix https://github.com/MadLittleMods/node-usb-detection/issues/78

As discussed in https://github.com/MadLittleMods/node-usb-detection/issues/78#issuecomment-483892512

I added it to the FAQ section, but wasn't sure if it should live there or the docs for `.find()` proper, lmk if you'd rather it there, or both places.