### PR TITLE
Updated type definitions for 4.5.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for usb-detection 3.1.0
+// Type definitions for usb-detection 4.5.0
 // Project: https://github.com/MadLittleMods/node-usb-detection
 // Definitions by: Rob Moran <https://github.com/thegecko>
+//                 Rico Brase <https://github.com/RicoBrase>
 
 export interface Device {
     locationId: number;
@@ -13,7 +14,9 @@ export interface Device {
 }
 
 export function find(vid: number, pid: number, callback: (error: any, devices: Device[]) => any): void;
+export function find(vid: number, pid: number): Promise<Device[]>;
 export function find(vid: number, callback: (error: any, devices: Device[]) => any): void;
+export function find(vid: number): Promise<Device[]>;
 export function find(callback: (error: any, devices: Device[]) => any): void;
 export function find(): Promise<Device[]>;
 


### PR DESCRIPTION
Updated type definitions to node-usb-detection 4.5.0

Old type definitions only allowed `find()` function to return a `Promise` object, if the function was called without parameters.

The updated type definitions now accept `find(vid)` and `find(vid, pid)` as Promise-based functions as well - just as stated in the ReadMe:
> Note: All find calls return a promise even with the node-style callback flavors

_Technically_, the type definitons currently wont allow `find()` to be called with callback function parameter AND returning a Promise either - I could add that too, if desired.