### PR TITLE
Fix segmentation fault on linux when calling stopMonitoring()

### DIFF
--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -221,8 +221,7 @@ extern "C" {
 		Nan::SetMethod(target, "stopMonitoring", StopMonitoring);
 		InitDetection();
 
-		v8::Isolate *isolate =  target->GetIsolate();
-		node::AddEnvironmentCleanupHook(isolate, CleanupDetection, nullptr);
+		node::AtExit(CleanupDetection);
 	}
 }
 

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -220,6 +220,9 @@ extern "C" {
 		Nan::SetMethod(target, "startMonitoring", StartMonitoring);
 		Nan::SetMethod(target, "stopMonitoring", StopMonitoring);
 		InitDetection();
+
+		v8::Isolate *isolate =  target->GetIsolate();
+		node::AddEnvironmentCleanupHook(isolate, CleanupDetection, nullptr);
 	}
 }
 

--- a/src/detection.h
+++ b/src/detection.h
@@ -18,6 +18,7 @@ void Find(const Nan::FunctionCallbackInfo<v8::Value>& args);
 void EIO_Find(uv_work_t* req);
 void EIO_AfterFind(uv_work_t* req);
 void InitDetection();
+void CleanupDetection(void*);
 void StartMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args);
 void Start();
 void StopMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args);

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -118,6 +118,12 @@ void InitDetection() {
 	BuildInitialDeviceList();
 }
 
+void CleanupDetection(void*) {
+	Stop();
+
+	udev_monitor_unref(mon);
+	udev_unref(udev);
+}
 
 void EIO_Find(uv_work_t* req) {
 	ListBaton* data = static_cast<ListBaton*>(req->data);
@@ -242,8 +248,6 @@ static void cbWork(uv_work_t *req) {
 
 static void cbAfter(uv_work_t *req, int status) {
 	Stop();
-	udev_monitor_unref(mon);
-	udev_unref(udev);
 }
 
 static void cbAsync(uv_async_t *handle) {

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -96,9 +96,6 @@ void Stop() {
 	uv_signal_stop(&term_signal);
 	uv_close((uv_handle_t *) &async_handler, NULL);
 	uv_cond_destroy(&notifyDeviceHandled);
-
-	udev_monitor_unref(mon);
-	udev_unref(udev);
 }
 
 void InitDetection() {
@@ -245,6 +242,8 @@ static void cbWork(uv_work_t *req) {
 
 static void cbAfter(uv_work_t *req, int status) {
 	Stop();
+	udev_monitor_unref(mon);
+	udev_unref(udev);
 }
 
 static void cbAsync(uv_async_t *handle) {

--- a/src/detection_mac.cpp
+++ b/src/detection_mac.cpp
@@ -400,6 +400,10 @@ void InitDetection() {
 	initialDeviceImport = false;
 }
 
+void CleanupDetection(void*) {
+	Stop();
+}
+
 void EIO_Find(uv_work_t* req) {
 	ListBaton* data = static_cast<ListBaton*>(req->data);
 

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -241,6 +241,9 @@ void InitDetection() {
 	BuildInitialDeviceList();
 }
 
+void CleanupDetection(void*) {
+	Stop();
+}
 
 void EIO_Find(uv_work_t* req) {
 


### PR DESCRIPTION
udev_monitor_unref was called while cbWork was still accessing the monitor.
Fixed by moving to cbAfter.

Resolves #57