### PR TITLE
Make the module Context Aware

### DIFF
--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -213,7 +213,7 @@ void StopMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 }
 
 extern "C" {
-	void init (v8::Local<v8::Object> target) {
+	NAN_MODULE_INIT(Init) {
 		Nan::SetMethod(target, "find", Find);
 		Nan::SetMethod(target, "registerAdded", RegisterAdded);
 		Nan::SetMethod(target, "registerRemoved", RegisterRemoved);
@@ -223,4 +223,8 @@ extern "C" {
 	}
 }
 
-NODE_MODULE(detection, init);
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(detection, Init)
+#else
+NODE_MODULE(detection, Init)
+#endif


### PR DESCRIPTION
Hello,
this is a solve for the issue #102 

I tested this on Electron 8.3.4 with 
`app.allowRendererProcessReuse = true;` 
and
`app.allowRendererProcessReuse = false;`

in both tests the module behaves as expected.

I don't know if there is further modification to be done (Cleanup or some other Tweaks).

this PR is Inspired by this [PR](https://github.com/atom/node-keytar/pull/182/files) 
and this [Commit](https://github.com/node-hid/node-hid/commit/cd2071427908a1820446e02bb41ef0b89f6b5f62)

I hope it helps :D 
