### PR TITLE
chore(package.json): use SPDX identifier for MIT in license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
   "bugs": {
     "url": "https://github.com/MadLittleMods/node-usb-detection/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://raw.github.com/MadLittleMods/node-usb-detection/master/licence"
-  },
+  "license": "MIT",
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
I noticed a little problem with the `license` field in the` package.json` when my editor popping up a warning about it:

- Using an object to specify a project's license in `package.json` is deprecated ([source: npm docs](https://docs.npmjs.com/files/package.json#license))
- The URL currently specified in that object is incorrect

This PR fixes these issues by replacing the value of `license` with the SPDX identifier `MIT`, which is recommended by the npm docs linked above