### PR TITLE
Rewrite based around napi and context aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,6 @@
 npm install usb-detection
 ```
 
-## Install for Electron
-
-This module uses native extensions and needs to be compiled for your target version of Electron. Precompiled binaries for recent Node.js and Electron versions are built and published using [prebuild][] and can be installed automatically using [electron-rebuild][].
-
-See the [Electron docs for using native modules][electron-native-modules] to ensure your project is set up to correctly use the prebuilt binaries for your version of Electron.
-
-[prebuild]: https://github.com/prebuild/prebuild
-[electron-rebuild]: https://github.com/electron/electron-rebuild
-[electron-native-modules]: https://www.electronjs.org/docs/tutorial/using-native-node-modules
-
----
-
-If you run into the following error, here are the exact steps you can use:
-
-```
-detection.node was compiled against a different Node.js version using NODE_MODULE_VERSION 72. This version of Node.js requires NODE_MODULE_VERSION 80. Please try re-compiling or re-installing 
-```
-
- 1. `npm i electron-rebuild --save-dev`
- 1. `./node_modules/.bin/electron-rebuild`
-
-
 # Usage
 
 ```js

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,7 @@
         "src/deviceList.cpp"
       ],
       "include_dirs" : [
+        "<!@(node -p \"require('node-addon-api').include\")" 
       ],
       'conditions': [
         ['OS=="win"',

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,14 @@
       "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
         # "CLANG_CXX_LIBRARY": "libc++",
         "MACOSX_DEPLOYMENT_TARGET": "10.7",
+        "OTHER_CFLAGS": [
+          "-arch x86_64",
+          "-arch arm64"
+        ],
+        "OTHER_LDFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
+          ]
       },
       "msvs_settings": {
         "VCCLCompilerTool": { "ExceptionHandling": 1 },

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,13 +2,21 @@
   "targets": [
     {
       "target_name": "detection",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "sources": [
         "src/detection.cpp",
         "src/detection.h",
         "src/deviceList.cpp"
       ],
       "include_dirs" : [
-        "<!(node -e \"require('nan')\")"
       ],
       'conditions': [
         ['OS=="win"',

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
       "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
+        # "CLANG_CXX_LIBRARY": "libc++",
         "MACOSX_DEPLOYMENT_TARGET": "10.7",
       },
       "msvs_settings": {

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export function find(vid: number): Promise<Device[]>;
 export function find(callback: (error: any, devices: Device[]) => any): void;
 export function find(): Promise<Device[]>;
 
+export function isMonitoring(): boolean;
 export function startMonitoring(): void;
 export function stopMonitoring(): void;
 export function on(event: string, callback: (device: Device) => void): void;

--- a/index.js
+++ b/index.js
@@ -10,8 +10,10 @@ function isFunction(functionToCheck) {
 if(global[index.name] && global[index.name].version === index.version) {
 	module.exports = global[index.name];
 } else {
-	var detection = require('bindings')('detection.node');
+	var binding = require('bindings')('detection.node');
 	var EventEmitter2 = require('eventemitter2').EventEmitter2;
+
+	var detectionInstance = new binding.Detection();
 
 	var detector = new EventEmitter2({
 		wildcard: true,
@@ -57,7 +59,7 @@ if(global[index.name] && global[index.name].version === index.version) {
 			});
 
 			// Fire off the `find` function that actually does all of the work
-			detection.find.apply(detection, args);
+			binding.find.apply(binding, args);
 		});
 	};
 
@@ -99,15 +101,15 @@ if(global[index.name] && global[index.name].version === index.version) {
 	}
 
 	detector.isMonitoring = function() {
-		return detection.isMonitoring();
-	}
+		return detectionInstance.isMonitoring();
+	};
 
 	detector.startMonitoring = function() {
-		detection.startMonitoring(fireEvent);
+		detectionInstance.startMonitoring(fireEvent);
 	};
 
 	detector.stopMonitoring = function() {
-		detection.stopMonitoring();
+		detectionInstance.stopMonitoring();
 	};
 
 	detector.version = index.version;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var SegfaultHandler = require('segfault-handler');
-SegfaultHandler.registerHandler();
+// var SegfaultHandler = require('segfault-handler');
+// SegfaultHandler.registerHandler();
 
 var index = require('./package.json');
 
@@ -47,7 +47,7 @@ if(global[index.name] && global[index.name].version === index.version) {
 			
 			// We call the callback if they passed one
 			if(callback) {
-				callback.call(callback, null, devices);
+				callback.call(callback, undefined, devices);
 			}
 
 			resolve(devices)

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ if(global[index.name] && global[index.name].version === index.version) {
 	var binding = require('bindings')('detection.node');
 	var EventEmitter2 = require('eventemitter2').EventEmitter2;
 
-	var detectionInstance = new binding.Detection();
+	var detection = new binding.Detection();
 
 	var detector = new EventEmitter2({
 		wildcard: true,
@@ -42,24 +42,15 @@ if(global[index.name] && global[index.name].version === index.version) {
 				args.push(pid);
 			}
 
-			// Tack on our own callback that takes care of things
-			args.push(function(err, devices) {
-
-				// We call the callback if they passed one
-				if(callback) {
-					callback.call(callback, err, devices);
-				}
-
-				// But also do the promise stuff
-				if(err) {
-					reject(err);
-					return;
-				}
-				resolve(devices);
-			});
-
 			// Fire off the `find` function that actually does all of the work
-			binding.find.apply(binding, args);
+			const devices = detection.findDevices.apply(detection, args);
+			
+			// We call the callback if they passed one
+			if(callback) {
+				callback.call(callback, null, devices);
+			}
+
+			resolve(devices)
 		});
 	};
 
@@ -101,15 +92,15 @@ if(global[index.name] && global[index.name].version === index.version) {
 	}
 
 	detector.isMonitoring = function() {
-		return detectionInstance.isMonitoring();
+		return detection.isMonitoring();
 	};
 
 	detector.startMonitoring = function() {
-		detectionInstance.startMonitoring(fireEvent);
+		detection.startMonitoring(fireEvent);
 	};
 
 	detector.stopMonitoring = function() {
-		detectionInstance.stopMonitoring();
+		detection.stopMonitoring();
 	};
 
 	detector.version = index.version;

--- a/index.js
+++ b/index.js
@@ -98,23 +98,15 @@ if(global[index.name] && global[index.name].version === index.version) {
 		}
 	}
 
-	var started = false;
+	detector.isMonitoring = function() {
+		return detection.isMonitoring();
+	}
 
 	detector.startMonitoring = function() {
-		if(started) {
-			return;
-		}
-
-		started = true;
 		detection.startMonitoring(fireEvent);
 	};
 
 	detector.stopMonitoring = function() {
-		if(!started) {
-			return;
-		}
-
-		started = false;
 		detection.stopMonitoring();
 	};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,6 +271,14 @@
         "chainsaw": "~0.1.0"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -1094,6 +1102,11 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "flat-cache": {
       "version": "1.3.0",
@@ -1982,11 +1995,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,11 +271,6 @@
         "chainsaw": "~0.1.0"
       }
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -2017,6 +2012,11 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "node-gyp": {
       "version": "7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,9 +241,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -342,12 +342,12 @@
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -357,9 +357,9 @@
       "dev": true
     },
     "buffer-indexof-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-      "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
       "dev": true
     },
     "buffer-shims": {
@@ -564,33 +564,6 @@
             "are-we-there-yet": "~1.0.0",
             "gauge": "~1.2.0"
           }
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
-        },
-        "tar": {
-          "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
         }
       }
     },
@@ -709,12 +682,12 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -1060,9 +1033,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
           "dev": true
         }
       }
@@ -1294,14 +1267,15 @@
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
+        "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "2 || 3",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -1498,9 +1472,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "3.3.8",
@@ -1530,9 +1504,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1780,9 +1754,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "string_decoder": {
@@ -1862,6 +1836,23 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "memory-stream": {
       "version": "0.0.3",
@@ -1975,6 +1966,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -2027,103 +2019,123 @@
       }
     },
     "node-gyp": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
-      "integrity": "sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
-        "mkdirp": "^0.5.1",
-        "nopt": "^4.0.1",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^5.0.0",
         "npmlog": "^4.1.2",
-        "request": "^2.88.0",
-        "rimraf": "^2.6.3",
-        "semver": "^5.7.1",
-        "tar": "^4.4.12",
-        "which": "^1.3.1"
+        "request": "^2.88.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "tar": "^6.0.2",
+        "which": "^2.0.2"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "minipass": "^3.0.0"
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
         "nopt": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
           "dev": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1"
           }
         },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
-        },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "tar": {
-          "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+          "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
@@ -2172,6 +2184,17 @@
             "ansi": "~0.3.1",
             "are-we-there-yet": "~1.1.2",
             "gauge": "~1.2.5"
+          }
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
           }
         }
       }
@@ -2247,25 +2270,22 @@
         "which": "1"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
         }
       }
     },
@@ -2403,9 +2423,9 @@
       "dev": true
     },
     "prebuild": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.0.tgz",
-      "integrity": "sha512-WLjsJRX7AJHw937oGyJT6wYscXYCfBVpCDU2shFG/B4rOcn5+3v5M2NoUrfkyVjjaCYLM61Kp7ulL1aNRygW8Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.1.tgz",
+      "integrity": "sha512-x0CkKDmHFwX49rTGEYJwB9jBQwJWxRzwUtP5PA9dP8khFGMm3oSFgYortxdlp0PkxB29EhWGp/KQE5g+adehYg==",
       "dev": true,
       "requires": {
         "cmake-js": "~5.2.0",
@@ -2414,6 +2434,7 @@
         "execspawn": "^1.0.1",
         "ghreleases": "^3.0.2",
         "github-from-package": "0.0.0",
+        "glob": "^7.1.6",
         "minimist": "^1.1.2",
         "mkdirp": "^0.5.1",
         "napi-build-utils": "^1.0.1",
@@ -2429,30 +2450,10 @@
         "tar-stream": "^2.1.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "node-gyp": {
@@ -2493,32 +2494,11 @@
             "glob": "^7.1.3"
           }
         },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
-        },
-        "tar": {
-          "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          }
         },
         "which": {
           "version": "1.3.1",
@@ -2528,25 +2508,19 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
         }
       }
     },
     "prebuild-install": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
-      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
+      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
-        "mkdirp": "^0.5.1",
+        "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
@@ -2612,13 +2586,6 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "readable-stream": {
@@ -2768,9 +2735,9 @@
       }
     },
     "run-waterfall": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
-      "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.7.tgz",
+      "integrity": "sha512-iFPgh7SatHXOG1ClcpdwHI63geV3Hc/iL6crGSyBlH2PY7Rm/za+zoKz6FfY/Qlw5K7JwSol8pseO8fN6CMhhQ==",
       "dev": true
     },
     "rx-lite": {
@@ -2983,47 +2950,51 @@
       }
     },
     "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
       },
       "dependencies": {
-        "fstream": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-          "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         }
       }
     },
     "tar-fs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
+        "tar-stream": "^2.1.4"
       }
     },
     "tar-stream": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3041,9 +3012,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "string_decoder": {
           "version": "1.3.0",
@@ -3143,6 +3114,19 @@
         "source-map-support": "~0.2.8"
       },
       "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
@@ -3415,9 +3399,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -40,10 +40,9 @@
     "node": ">=4"
   },
   "dependencies": {
-    "node-addon-api": "3.1.0",
+    "node-addon-api": "^3.1.0",
     "bindings": "^1.5.0",
     "eventemitter2": "^5.0.1",
-    "node-addon-api": "^3.1.0",
     "prebuild-install": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,18 +40,17 @@
     "node": ">=4"
   },
   "dependencies": {
-    "bindings": "^1.3.0",
+    "bindings": "^1.5.0",
     "eventemitter2": "^5.0.1",
     "nan": "^2.13.2",
-    "prebuild-install": "^5.3.5"
+    "prebuild-install": "^6.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "chalk": "^2.4.1",
     "eslint": "^4.19.1",
     "jasmine": "^3.1.0",
-    "node-abi": "^2.18.0",
-    "node-gyp": "^6.1.0",
-    "prebuild": "^10.0.0"
+    "node-gyp": "^7.1.2",
+    "prebuild": "^10.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "node": ">=4"
   },
   "dependencies": {
+    "node-addon-api": "3.1.0",
     "bindings": "^1.5.0",
     "eventemitter2": "^5.0.1",
-    "nan": "^2.13.2",
+    "node-addon-api": "^3.1.0",
     "prebuild-install": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "types": "index.d.ts",
   "gypfile": true,
   "scripts": {
-    "install": "prebuild-install || node-gyp rebuild",
+    "install": "prebuild-install --runtime napi || node-gyp rebuild",
     "prepublishOnly": "npm run validate",
     "lint": "eslint **/*.js",
     "validate": "npm run lint && npm test",
     "test": "jasmine ./test/test.js",
-    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild": "prebuild --all --strip --runtime napi --verbose",
     "rebuild": "node-gyp rebuild"
   },
   "repository": {
@@ -37,12 +37,17 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
+  },
+  "binary": {
+    "napi_versions": [
+      3
+    ]
   },
   "dependencies": {
-    "node-addon-api": "^3.1.0",
     "bindings": "^1.5.0",
     "eventemitter2": "^5.0.1",
+    "node-addon-api": "^3.1.0",
     "prebuild-install": "^6.0.0"
   },
   "devDependencies": {

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -8,6 +8,22 @@
 #define OBJECT_ITEM_SERIAL_NUMBER "serialNumber"
 #define OBJECT_ITEM_DEVICE_ADDRESS "deviceAddress"
 
+struct DeviceCallbackItem
+{
+	std::string type;
+	std::shared_ptr<ListResultItem_t> item;
+};
+
+static void DeviceItemChangeCallback(Napi::Env env, Napi::Function jsCallback, DeviceCallbackItem *data)
+{
+	Napi::Value type = Napi::String::From(env, data->type);
+	Napi::Value value = DeviceItemToObject(env, data->item);
+	jsCallback.Call({type, value});
+
+	// We're finished with the data.
+	delete data;
+};
+
 Detection::~Detection()
 {
 }
@@ -89,6 +105,34 @@ Napi::Value Detection::FindDevices(const Napi::CallbackInfo &args)
 	return results;
 }
 
+void Detection::DeviceAdded(const std::shared_ptr<ListResultItem_t> item)
+{
+	DeviceCallbackItem *data = new DeviceCallbackItem;
+	data->item = item;
+	data->type = "add";
+
+	napi_status status = notify_func.BlockingCall(data, DeviceItemChangeCallback);
+	if (status != napi_ok)
+	{
+		// Handle error
+		// TODO
+	}
+}
+
+void Detection::DeviceRemoved(const std::shared_ptr<ListResultItem_t> item)
+{
+	DeviceCallbackItem *data = new DeviceCallbackItem;
+	data->item = item;
+	data->type = "remove";
+
+	napi_status status = notify_func.BlockingCall(data, DeviceItemChangeCallback);
+	if (status != napi_ok)
+	{
+		// Handle error
+		// TODO
+	}
+}
+
 Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultItem_t> it)
 {
 	Napi::Object item = Napi::Object::New(env);
@@ -101,121 +145,6 @@ Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultI
 	item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
 	return item;
 }
-
-// void Find(const Napi::CallbackInfo &args)
-// {
-// 	Napi::HandleScope scope(env);
-
-// 	int vid = 0;
-// 	int pid = 0;
-// 	Napi::Function callback;
-
-// 	if (args.Length() == 0)
-// 	{
-// 		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-// 		return env.Null();
-// 	}
-
-// 	if (args.Length() >= 3)
-// 	{
-// 		if (args[0].IsNumber() && args[1].IsNumber())
-// 		{
-// 			vid = (int)args[0].As<Napi::Number>().Int32Value();
-// 			pid = (int)args[1].As<Napi::Number>().Int32Value();
-// 		}
-
-// 		// callback
-// 		if (!args[2]->IsFunction())
-// 		{
-// 			Napi::TypeError::New(env, "Third argument must be a function").ThrowAsJavaScriptException();
-// 			return env.Null();
-// 		}
-
-// 		callback = args[2].As<Napi::Function>();
-// 	}
-
-// 	if (args.Length() == 2)
-// 	{
-// 		if (args[0].IsNumber())
-// 		{
-// 			vid = (int)args[0].As<Napi::Number>().Int32Value();
-// 		}
-
-// 		// callback
-// 		if (!args[1]->IsFunction())
-// 		{
-// 			Napi::TypeError::New(env, "Second argument must be a function").ThrowAsJavaScriptException();
-// 			return env.Null();
-// 		}
-
-// 		callback = args[1].As<Napi::Function>();
-// 	}
-
-// 	if (args.Length() == 1)
-// 	{
-// 		// callback
-// 		if (!args[0]->IsFunction())
-// 		{
-// 			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-// 			return env.Null();
-// 		}
-
-// 		callback = args[0].As<Napi::Function>();
-// 	}
-
-// 	// ListBaton *baton = new ListBaton();
-// 	// strcpy(baton->errorString, "");
-// 	// baton->callback = new Napi::FunctionReference(callback);
-// 	// baton->vid = vid;
-// 	// baton->pid = pid;
-
-// 	// uv_work_t *req = new uv_work_t();
-// 	// req->data = baton;
-// 	// uv_queue_work(uv_default_loop(), req, EIO_Find, (uv_after_work_cb)EIO_AfterFind);
-// }
-
-// void EIO_AfterFind(uv_work_t *req)
-// {
-// 	Napi::HandleScope scope(env);
-
-// 	ListBaton *data = static_cast<ListBaton *>(req->data);
-
-// 	Napi::Value argv[2];
-// 	if (data->errorString[0])
-// 	{
-// 		argv[0] = v8::Exception::Error(Napi::String::New(env, data->errorString));
-// 		argv[1] = env.Undefined();
-// 	}
-// 	else
-// 	{
-// 		Napi::Array results = Napi::Array::New(env);
-// 		int i = 0;
-// 		for (std::list<ListResultItem_t *>::iterator it = data->results.begin(); it != data->results.end(); it++, i++)
-// 		{
-// 			Napi::Object item = Napi::Object::New(env);
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, (*it)->locationId));
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, (*it)->vendorId));
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, (*it)->productId));
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, (*it)->deviceName.c_str()));
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, (*it)->manufacturer.c_str()));
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, (*it)->serialNumber.c_str()));
-// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, (*it)->deviceAddress));
-// 			(results).Set(i, item);
-// 		}
-// 		argv[0] = env.Undefined();
-// 		argv[1] = results;
-// 	}
-
-// 	Napi::AsyncResource resource("usb-detection:EIO_AfterFind");
-// 	data->callback->Call(2, argv, &resource);
-
-// 	for (std::list<ListResultItem_t *>::iterator it = data->results.begin(); it != data->results.end(); it++)
-// 	{
-// 		delete *it;
-// 	}
-// 	delete data;
-// 	delete req;
-// }
 
 Napi::Object init(Napi::Env env, Napi::Object exports)
 {

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -10,154 +10,162 @@
 #define OBJECT_ITEM_DEVICE_ADDRESS "deviceAddress"
 
 
-Nan::Callback* addedCallback;
+Napi::FunctionReference* addedCallback;
 bool isAddedRegistered = false;
 
-Nan::Callback* removedCallback;
+Napi::FunctionReference* removedCallback;
 bool isRemovedRegistered = false;
 
-void RegisterAdded(const Nan::FunctionCallbackInfo<v8::Value>& args) {
-	Nan::HandleScope scope;
+void RegisterAdded(const Napi::CallbackInfo& args) {
+	Napi::HandleScope scope(env);
 
-	v8::Local<v8::Function> callback;
+	Napi::Function callback;
 
 	if (args.Length() == 0) {
-		return Nan::ThrowTypeError("First argument must be a function");
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 	}
 
 	if (args.Length() == 1) {
 		// callback
 		if(!args[0]->IsFunction()) {
-			return Nan::ThrowTypeError("First argument must be a function");
+			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 		}
 
-		callback = args[0].As<v8::Function>();
+		callback = args[0].As<Napi::Function>();
 	}
 
-	addedCallback = new Nan::Callback(callback);
+	addedCallback = new Napi::FunctionReference(callback);
 	isAddedRegistered = true;
 }
 
 void NotifyAdded(ListResultItem_t* it) {
-	Nan::HandleScope scope;
+	Napi::HandleScope scope(env);
 
 	if (it == NULL) {
 		return;
 	}
 
 	if (isAddedRegistered){
-		v8::Local<v8::Value> argv[1];
-		v8::Local<v8::Object> item = Nan::New<v8::Object>();
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_LOCATION_ID).ToLocalChecked(), Nan::New<v8::Number>(it->locationId));
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_VENDOR_ID).ToLocalChecked(), Nan::New<v8::Number>(it->vendorId));
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_PRODUCT_ID).ToLocalChecked(), Nan::New<v8::Number>(it->productId));
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_DEVICE_NAME).ToLocalChecked(), Nan::New<v8::String>(it->deviceName.c_str()).ToLocalChecked());
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_MANUFACTURER).ToLocalChecked(), Nan::New<v8::String>(it->manufacturer.c_str()).ToLocalChecked());
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_SERIAL_NUMBER).ToLocalChecked(), Nan::New<v8::String>(it->serialNumber.c_str()).ToLocalChecked());
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_DEVICE_ADDRESS).ToLocalChecked(), Nan::New<v8::Number>(it->deviceAddress));
+		Napi::Value argv[1];
+		Napi::Object item = Napi::Object::New(env);
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
 		argv[0] = item;
 
-		Nan::AsyncResource resource("usb-detection:NotifyAdded");
+		Napi::AsyncResource resource("usb-detection:NotifyAdded");
 		addedCallback->Call(1, argv, &resource);
 	}
 }
 
-void RegisterRemoved(const Nan::FunctionCallbackInfo<v8::Value>& args) {
-	Nan::HandleScope scope;
+void RegisterRemoved(const Napi::CallbackInfo& args) {
+	Napi::HandleScope scope(env);
 
-	v8::Local<v8::Function> callback;
+	Napi::Function callback;
 
 	if (args.Length() == 0) {
-		return Nan::ThrowTypeError("First argument must be a function");
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 	}
 
 	if (args.Length() == 1) {
 		// callback
 		if(!args[0]->IsFunction()) {
-			return Nan::ThrowTypeError("First argument must be a function");
+			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 		}
 
-		callback = args[0].As<v8::Function>();
+		callback = args[0].As<Napi::Function>();
 	}
 
-	removedCallback = new Nan::Callback(callback);
+	removedCallback = new Napi::FunctionReference(callback);
 	isRemovedRegistered = true;
 }
 
 void NotifyRemoved(ListResultItem_t* it) {
-	Nan::HandleScope scope;
+	Napi::HandleScope scope(env);
 
 	if (it == NULL) {
 		return;
 	}
 
 	if (isRemovedRegistered) {
-		v8::Local<v8::Value> argv[1];
-		v8::Local<v8::Object> item = Nan::New<v8::Object>();
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_LOCATION_ID).ToLocalChecked(), Nan::New<v8::Number>(it->locationId));
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_VENDOR_ID).ToLocalChecked(), Nan::New<v8::Number>(it->vendorId));
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_PRODUCT_ID).ToLocalChecked(), Nan::New<v8::Number>(it->productId));
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_DEVICE_NAME).ToLocalChecked(), Nan::New<v8::String>(it->deviceName.c_str()).ToLocalChecked());
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_MANUFACTURER).ToLocalChecked(), Nan::New<v8::String>(it->manufacturer.c_str()).ToLocalChecked());
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_SERIAL_NUMBER).ToLocalChecked(), Nan::New<v8::String>(it->serialNumber.c_str()).ToLocalChecked());
-		Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_DEVICE_ADDRESS).ToLocalChecked(), Nan::New<v8::Number>(it->deviceAddress));
+		Napi::Value argv[1];
+		Napi::Object item = Napi::Object::New(env);
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
+		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
 		argv[0] = item;
 		
-		Nan::AsyncResource resource("usb-detection:NotifyRemoved");
+		Napi::AsyncResource resource("usb-detection:NotifyRemoved");
 		removedCallback->Call(1, argv, &resource);
 	}
 }
 
-void Find(const Nan::FunctionCallbackInfo<v8::Value>& args) {
-	Nan::HandleScope scope;
+void Find(const Napi::CallbackInfo& args) {
+	Napi::HandleScope scope(env);
 
 	int vid = 0;
 	int pid = 0;
-	v8::Local<v8::Function> callback;
+	Napi::Function callback;
 
 	if (args.Length() == 0) {
-		return Nan::ThrowTypeError("First argument must be a function");
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 	}
 
 	if (args.Length() == 3) {
-		if (args[0]->IsNumber() && args[1]->IsNumber()) {
-			vid = (int) Nan::To<int>(args[0]).FromJust();
-			pid = (int) Nan::To<int>(args[1]).FromJust();
+		if (args[0].IsNumber() && args[1].IsNumber()) {
+			vid = (int) args[0].As<Napi::Number>().Int32Value();
+			pid = (int) args[1].As<Napi::Number>().Int32Value();
 		}
 
 		// callback
 		if(!args[2]->IsFunction()) {
-			return Nan::ThrowTypeError("Third argument must be a function");
+			Napi::TypeError::New(env, "Third argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 		}
 
-		callback = args[2].As<v8::Function>();
+		callback = args[2].As<Napi::Function>();
 	}
 
 	if (args.Length() == 2) {
-		if (args[0]->IsNumber()) {
-			vid = (int) Nan::To<int>(args[0]).FromJust();
+		if (args[0].IsNumber()) {
+			vid = (int) args[0].As<Napi::Number>().Int32Value();
 		}
 
 		// callback
 		if(!args[1]->IsFunction()) {
-			return Nan::ThrowTypeError("Second argument must be a function");
+			Napi::TypeError::New(env, "Second argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 		}
 
-		callback = args[1].As<v8::Function>();
+		callback = args[1].As<Napi::Function>();
 	}
 
 	if (args.Length() == 1) {
 		// callback
 		if(!args[0]->IsFunction()) {
-			return Nan::ThrowTypeError("First argument must be a function");
+			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+return env.Null();
 		}
 
-		callback = args[0].As<v8::Function>();
+		callback = args[0].As<Napi::Function>();
 	}
 
 	ListBaton* baton = new ListBaton();
 	strcpy(baton->errorString, "");
-	baton->callback = new Nan::Callback(callback);
+	baton->callback = new Napi::FunctionReference(callback);
 	baton->vid = vid;
 	baton->pid = pid;
 
@@ -167,34 +175,34 @@ void Find(const Nan::FunctionCallbackInfo<v8::Value>& args) {
 }
 
 void EIO_AfterFind(uv_work_t* req) {
-	Nan::HandleScope scope;
+	Napi::HandleScope scope(env);
 
 	ListBaton* data = static_cast<ListBaton*>(req->data);
 
-	v8::Local<v8::Value> argv[2];
+	Napi::Value argv[2];
 	if(data->errorString[0]) {
-		argv[0] = v8::Exception::Error(Nan::New<v8::String>(data->errorString).ToLocalChecked());
-		argv[1] = Nan::Undefined();
+		argv[0] = v8::Exception::Error(Napi::String::New(env, data->errorString));
+		argv[1] = env.Undefined();
 	}
 	else {
-		v8::Local<v8::Array> results = Nan::New<v8::Array>();
+		Napi::Array results = Napi::Array::New(env);
 		int i = 0;
 		for(std::list<ListResultItem_t*>::iterator it = data->results.begin(); it != data->results.end(); it++, i++) {
-			v8::Local<v8::Object> item = Nan::New<v8::Object>();
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_LOCATION_ID).ToLocalChecked(), Nan::New<v8::Number>((*it)->locationId));
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_VENDOR_ID).ToLocalChecked(), Nan::New<v8::Number>((*it)->vendorId));
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_PRODUCT_ID).ToLocalChecked(), Nan::New<v8::Number>((*it)->productId));
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_DEVICE_NAME).ToLocalChecked(), Nan::New<v8::String>((*it)->deviceName.c_str()).ToLocalChecked());
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_MANUFACTURER).ToLocalChecked(), Nan::New<v8::String>((*it)->manufacturer.c_str()).ToLocalChecked());
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_SERIAL_NUMBER).ToLocalChecked(), Nan::New<v8::String>((*it)->serialNumber.c_str()).ToLocalChecked());
-			Nan::Set(item, Nan::New<v8::String>(OBJECT_ITEM_DEVICE_ADDRESS).ToLocalChecked(), Nan::New<v8::Number>((*it)->deviceAddress));
-			Nan::Set(results, i, item);
+			Napi::Object item = Napi::Object::New(env);
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, (*it)->locationId));
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, (*it)->vendorId));
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, (*it)->productId));
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, (*it)->deviceName.c_str()));
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, (*it)->manufacturer.c_str()));
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, (*it)->serialNumber.c_str()));
+			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, (*it)->deviceAddress));
+			(results).Set(i, item);
 		}
-		argv[0] = Nan::Undefined();
+		argv[0] = env.Undefined();
 		argv[1] = results;
 	}
 
-	Nan::AsyncResource resource("usb-detection:EIO_AfterFind");
+	Napi::AsyncResource resource("usb-detection:EIO_AfterFind");
 	data->callback->Call(2, argv, &resource);
 
 	for(std::list<ListResultItem_t*>::iterator it = data->results.begin(); it != data->results.end(); it++) {
@@ -204,23 +212,23 @@ void EIO_AfterFind(uv_work_t* req) {
 	delete req;
 }
 
-void StartMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args) {
+void StartMonitoring(const Napi::CallbackInfo& args) {
 	Start();
 }
 
-void StopMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args) {
+void StopMonitoring(const Napi::CallbackInfo& args) {
 	Stop();
 }
 
 extern "C" {
-	void init (v8::Local<v8::Object> target) {
-		Nan::SetMethod(target, "find", Find);
-		Nan::SetMethod(target, "registerAdded", RegisterAdded);
-		Nan::SetMethod(target, "registerRemoved", RegisterRemoved);
-		Nan::SetMethod(target, "startMonitoring", StartMonitoring);
-		Nan::SetMethod(target, "stopMonitoring", StopMonitoring);
+	void init (Napi::Object target) {
+		exports.Set(Napi::String::New(env, "find"), Napi::Function::New(env, Find));
+		exports.Set(Napi::String::New(env, "registerAdded"), Napi::Function::New(env, RegisterAdded));
+		exports.Set(Napi::String::New(env, "registerRemoved"), Napi::Function::New(env, RegisterRemoved));
+		exports.Set(Napi::String::New(env, "startMonitoring"), Napi::Function::New(env, StartMonitoring));
+		exports.Set(Napi::String::New(env, "stopMonitoring"), Napi::Function::New(env, StopMonitoring));
 		InitDetection();
 	}
 }
 
-NODE_MODULE(detection, init);
+NODE_API_MODULE(detection, init);

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -8,77 +8,6 @@
 #define OBJECT_ITEM_SERIAL_NUMBER "serialNumber"
 #define OBJECT_ITEM_DEVICE_ADDRESS "deviceAddress"
 
-Napi::FunctionReference addedCallback;
-bool isAddedRegistered = false;
-
-Napi::FunctionReference removedCallback;
-bool isRemovedRegistered = false;
-
-Napi::Value RegisterAdded(const Napi::CallbackInfo &args)
-{
-	Napi::Env env = args.Env();
-
-	if (args.Length() == 0)
-	{
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	// callback
-	if (!args[0].IsFunction())
-	{
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	addedCallback = Napi::Persistent(args[0].As<Napi::Function>());
-	isAddedRegistered = true;
-
-	return env.Null();
-}
-
-void NotifyAdded(ListResultItem_t *it)
-{
-	if (it != nullptr && isAddedRegistered)
-	{
-		Napi::Env env = addedCallback.Env();
-
-		Napi::Object item = Napi::Object::New(env);
-		item.Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
-
-		addedCallback.Call({item});
-	}
-}
-
-Napi::Value RegisterRemoved(const Napi::CallbackInfo &args)
-{
-	Napi::Env env = args.Env();
-
-	if (args.Length() == 0)
-	{
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	// callback
-	if (!args[0].IsFunction())
-	{
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	removedCallback = Napi::Persistent(args[0].As<Napi::Function>());
-	isRemovedRegistered = true;
-
-	return env.Null();
-}
-
 Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultItem_t> it)
 {
 	Napi::Object item = Napi::Object::New(env);
@@ -90,25 +19,6 @@ Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultI
 	item.Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
 	item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
 	return item;
-}
-
-void NotifyRemoved(ListResultItem_t *it)
-{
-	if (it != nullptr && isRemovedRegistered)
-	{
-		Napi::Env env = removedCallback.Env();
-
-		Napi::Object item = Napi::Object::New(env);
-		item.Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
-		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
-
-		removedCallback.Call({item});
-	}
 }
 
 // class FindWorker : public Napi::AsyncWorker
@@ -316,8 +226,6 @@ Napi::Value IsMonitoring(const Napi::CallbackInfo &args)
 Napi::Object init(Napi::Env env, Napi::Object exports)
 {
 	// exports.Set(Napi::String::New(env, "find"), Napi::Function::New(env, Find));
-	exports.Set(Napi::String::New(env, "registerAdded"), Napi::Function::New(env, RegisterAdded));
-	exports.Set(Napi::String::New(env, "registerRemoved"), Napi::Function::New(env, RegisterRemoved));
 	exports.Set(Napi::String::New(env, "startMonitoring"), Napi::Function::New(env, StartMonitoring));
 	exports.Set(Napi::String::New(env, "stopMonitoring"), Napi::Function::New(env, StopMonitoring));
 	exports.Set(Napi::String::New(env, "isMonitoring"), Napi::Function::New(env, IsMonitoring));

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -1,6 +1,5 @@
 #include "detection.h"
 
-
 #define OBJECT_ITEM_LOCATION_ID "locationId"
 #define OBJECT_ITEM_VENDOR_ID "vendorId"
 #define OBJECT_ITEM_PRODUCT_ID "productId"
@@ -9,226 +8,230 @@
 #define OBJECT_ITEM_SERIAL_NUMBER "serialNumber"
 #define OBJECT_ITEM_DEVICE_ADDRESS "deviceAddress"
 
-
-Napi::FunctionReference* addedCallback;
+Napi::FunctionReference addedCallback;
 bool isAddedRegistered = false;
 
-Napi::FunctionReference* removedCallback;
+Napi::FunctionReference removedCallback;
 bool isRemovedRegistered = false;
 
-void RegisterAdded(const Napi::CallbackInfo& args) {
-	Napi::HandleScope scope(env);
+Napi::Value RegisterAdded(const Napi::CallbackInfo &args)
+{
+	Napi::Env env = args.Env();
 
-	Napi::Function callback;
-
-	if (args.Length() == 0) {
+	if (args.Length() == 0)
+	{
 		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
+		return env.Null();
 	}
 
-	if (args.Length() == 1) {
-		// callback
-		if(!args[0]->IsFunction()) {
-			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
-		}
-
-		callback = args[0].As<Napi::Function>();
+	// callback
+	if (!args[0].IsFunction())
+	{
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+		return env.Null();
 	}
 
-	addedCallback = new Napi::FunctionReference(callback);
+	addedCallback = Napi::Persistent(args[0].As<Napi::Function>());
 	isAddedRegistered = true;
+
+	return env.Null();
 }
 
-void NotifyAdded(ListResultItem_t* it) {
-	Napi::HandleScope scope(env);
+void NotifyAdded(ListResultItem_t *it)
+{
+	if (it != nullptr && isAddedRegistered)
+	{
+		Napi::Env env = addedCallback.Env();
 
-	if (it == NULL) {
-		return;
-	}
-
-	if (isAddedRegistered){
-		Napi::Value argv[1];
 		Napi::Object item = Napi::Object::New(env);
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
-		argv[0] = item;
+		item.Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
 
-		Napi::AsyncResource resource("usb-detection:NotifyAdded");
-		addedCallback->Call(1, argv, &resource);
+		addedCallback.Call({item});
 	}
 }
 
-void RegisterRemoved(const Napi::CallbackInfo& args) {
-	Napi::HandleScope scope(env);
+Napi::Value RegisterRemoved(const Napi::CallbackInfo &args)
+{
+	Napi::Env env = args.Env();
 
-	Napi::Function callback;
-
-	if (args.Length() == 0) {
+	if (args.Length() == 0)
+	{
 		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
+		return env.Null();
 	}
 
-	if (args.Length() == 1) {
-		// callback
-		if(!args[0]->IsFunction()) {
-			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
-		}
-
-		callback = args[0].As<Napi::Function>();
+	// callback
+	if (!args[0].IsFunction())
+	{
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+		return env.Null();
 	}
 
-	removedCallback = new Napi::FunctionReference(callback);
+	removedCallback = Napi::Persistent(args[0].As<Napi::Function>());
 	isRemovedRegistered = true;
+
+	return env.Null();
 }
 
-void NotifyRemoved(ListResultItem_t* it) {
-	Napi::HandleScope scope(env);
+void NotifyRemoved(ListResultItem_t *it)
+{
+	if (it != nullptr && isRemovedRegistered)
+	{
+		Napi::Env env = removedCallback.Env();
 
-	if (it == NULL) {
-		return;
-	}
-
-	if (isRemovedRegistered) {
-		Napi::Value argv[1];
 		Napi::Object item = Napi::Object::New(env);
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
-		(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
-		argv[0] = item;
-		
-		Napi::AsyncResource resource("usb-detection:NotifyRemoved");
-		removedCallback->Call(1, argv, &resource);
+		item.Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, it->locationId));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, it->vendorId));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, it->productId));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, it->deviceName.c_str()));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, it->manufacturer.c_str()));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, it->serialNumber.c_str()));
+		item.Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, it->deviceAddress));
+
+		removedCallback.Call({item});
 	}
 }
 
-void Find(const Napi::CallbackInfo& args) {
-	Napi::HandleScope scope(env);
+// void Find(const Napi::CallbackInfo &args)
+// {
+// 	Napi::HandleScope scope(env);
 
-	int vid = 0;
-	int pid = 0;
-	Napi::Function callback;
+// 	int vid = 0;
+// 	int pid = 0;
+// 	Napi::Function callback;
 
-	if (args.Length() == 0) {
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
-	}
+// 	if (args.Length() == 0)
+// 	{
+// 		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+// 		return env.Null();
+// 	}
 
-	if (args.Length() == 3) {
-		if (args[0].IsNumber() && args[1].IsNumber()) {
-			vid = (int) args[0].As<Napi::Number>().Int32Value();
-			pid = (int) args[1].As<Napi::Number>().Int32Value();
-		}
+// 	if (args.Length() == 3)
+// 	{
+// 		if (args[0].IsNumber() && args[1].IsNumber())
+// 		{
+// 			vid = (int)args[0].As<Napi::Number>().Int32Value();
+// 			pid = (int)args[1].As<Napi::Number>().Int32Value();
+// 		}
 
-		// callback
-		if(!args[2]->IsFunction()) {
-			Napi::TypeError::New(env, "Third argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
-		}
+// 		// callback
+// 		if (!args[2]->IsFunction())
+// 		{
+// 			Napi::TypeError::New(env, "Third argument must be a function").ThrowAsJavaScriptException();
+// 			return env.Null();
+// 		}
 
-		callback = args[2].As<Napi::Function>();
-	}
+// 		callback = args[2].As<Napi::Function>();
+// 	}
 
-	if (args.Length() == 2) {
-		if (args[0].IsNumber()) {
-			vid = (int) args[0].As<Napi::Number>().Int32Value();
-		}
+// 	if (args.Length() == 2)
+// 	{
+// 		if (args[0].IsNumber())
+// 		{
+// 			vid = (int)args[0].As<Napi::Number>().Int32Value();
+// 		}
 
-		// callback
-		if(!args[1]->IsFunction()) {
-			Napi::TypeError::New(env, "Second argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
-		}
+// 		// callback
+// 		if (!args[1]->IsFunction())
+// 		{
+// 			Napi::TypeError::New(env, "Second argument must be a function").ThrowAsJavaScriptException();
+// 			return env.Null();
+// 		}
 
-		callback = args[1].As<Napi::Function>();
-	}
+// 		callback = args[1].As<Napi::Function>();
+// 	}
 
-	if (args.Length() == 1) {
-		// callback
-		if(!args[0]->IsFunction()) {
-			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-return env.Null();
-		}
+// 	if (args.Length() == 1)
+// 	{
+// 		// callback
+// 		if (!args[0]->IsFunction())
+// 		{
+// 			Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+// 			return env.Null();
+// 		}
 
-		callback = args[0].As<Napi::Function>();
-	}
+// 		callback = args[0].As<Napi::Function>();
+// 	}
 
-	ListBaton* baton = new ListBaton();
-	strcpy(baton->errorString, "");
-	baton->callback = new Napi::FunctionReference(callback);
-	baton->vid = vid;
-	baton->pid = pid;
+// 	ListBaton *baton = new ListBaton();
+// 	strcpy(baton->errorString, "");
+// 	baton->callback = new Napi::FunctionReference(callback);
+// 	baton->vid = vid;
+// 	baton->pid = pid;
 
-	uv_work_t* req = new uv_work_t();
-	req->data = baton;
-	uv_queue_work(uv_default_loop(), req, EIO_Find, (uv_after_work_cb)EIO_AfterFind);
-}
+// 	uv_work_t *req = new uv_work_t();
+// 	req->data = baton;
+// 	uv_queue_work(uv_default_loop(), req, EIO_Find, (uv_after_work_cb)EIO_AfterFind);
+// }
 
-void EIO_AfterFind(uv_work_t* req) {
-	Napi::HandleScope scope(env);
+// void EIO_AfterFind(uv_work_t *req)
+// {
+// 	Napi::HandleScope scope(env);
 
-	ListBaton* data = static_cast<ListBaton*>(req->data);
+// 	ListBaton *data = static_cast<ListBaton *>(req->data);
 
-	Napi::Value argv[2];
-	if(data->errorString[0]) {
-		argv[0] = v8::Exception::Error(Napi::String::New(env, data->errorString));
-		argv[1] = env.Undefined();
-	}
-	else {
-		Napi::Array results = Napi::Array::New(env);
-		int i = 0;
-		for(std::list<ListResultItem_t*>::iterator it = data->results.begin(); it != data->results.end(); it++, i++) {
-			Napi::Object item = Napi::Object::New(env);
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, (*it)->locationId));
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, (*it)->vendorId));
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, (*it)->productId));
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, (*it)->deviceName.c_str()));
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, (*it)->manufacturer.c_str()));
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, (*it)->serialNumber.c_str()));
-			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, (*it)->deviceAddress));
-			(results).Set(i, item);
-		}
-		argv[0] = env.Undefined();
-		argv[1] = results;
-	}
+// 	Napi::Value argv[2];
+// 	if (data->errorString[0])
+// 	{
+// 		argv[0] = v8::Exception::Error(Napi::String::New(env, data->errorString));
+// 		argv[1] = env.Undefined();
+// 	}
+// 	else
+// 	{
+// 		Napi::Array results = Napi::Array::New(env);
+// 		int i = 0;
+// 		for (std::list<ListResultItem_t *>::iterator it = data->results.begin(); it != data->results.end(); it++, i++)
+// 		{
+// 			Napi::Object item = Napi::Object::New(env);
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_LOCATION_ID), Napi::Number::New(env, (*it)->locationId));
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_VENDOR_ID), Napi::Number::New(env, (*it)->vendorId));
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_PRODUCT_ID), Napi::Number::New(env, (*it)->productId));
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_NAME), Napi::String::New(env, (*it)->deviceName.c_str()));
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_MANUFACTURER), Napi::String::New(env, (*it)->manufacturer.c_str()));
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_SERIAL_NUMBER), Napi::String::New(env, (*it)->serialNumber.c_str()));
+// 			(item).Set(Napi::String::New(env, OBJECT_ITEM_DEVICE_ADDRESS), Napi::Number::New(env, (*it)->deviceAddress));
+// 			(results).Set(i, item);
+// 		}
+// 		argv[0] = env.Undefined();
+// 		argv[1] = results;
+// 	}
 
-	Napi::AsyncResource resource("usb-detection:EIO_AfterFind");
-	data->callback->Call(2, argv, &resource);
+// 	Napi::AsyncResource resource("usb-detection:EIO_AfterFind");
+// 	data->callback->Call(2, argv, &resource);
 
-	for(std::list<ListResultItem_t*>::iterator it = data->results.begin(); it != data->results.end(); it++) {
-		delete *it;
-	}
-	delete data;
-	delete req;
-}
+// 	for (std::list<ListResultItem_t *>::iterator it = data->results.begin(); it != data->results.end(); it++)
+// 	{
+// 		delete *it;
+// 	}
+// 	delete data;
+// 	delete req;
+// }
 
-void StartMonitoring(const Napi::CallbackInfo& args) {
+void StartMonitoring(const Napi::CallbackInfo &args)
+{
 	Start();
 }
 
-void StopMonitoring(const Napi::CallbackInfo& args) {
+void StopMonitoring(const Napi::CallbackInfo &args)
+{
 	Stop();
 }
 
-extern "C" {
-	void init (Napi::Object target) {
-		exports.Set(Napi::String::New(env, "find"), Napi::Function::New(env, Find));
-		exports.Set(Napi::String::New(env, "registerAdded"), Napi::Function::New(env, RegisterAdded));
-		exports.Set(Napi::String::New(env, "registerRemoved"), Napi::Function::New(env, RegisterRemoved));
-		exports.Set(Napi::String::New(env, "startMonitoring"), Napi::Function::New(env, StartMonitoring));
-		exports.Set(Napi::String::New(env, "stopMonitoring"), Napi::Function::New(env, StopMonitoring));
-		InitDetection();
-	}
+Napi::Object init(Napi::Env env, Napi::Object exports)
+{
+	// exports.Set(Napi::String::New(env, "find"), Napi::Function::New(env, Find));
+	exports.Set(Napi::String::New(env, "registerAdded"), Napi::Function::New(env, RegisterAdded));
+	exports.Set(Napi::String::New(env, "registerRemoved"), Napi::Function::New(env, RegisterRemoved));
+	exports.Set(Napi::String::New(env, "startMonitoring"), Napi::Function::New(env, StartMonitoring));
+	exports.Set(Napi::String::New(env, "stopMonitoring"), Napi::Function::New(env, StopMonitoring));
+	InitDetection();
+	return exports;
 }
 
 NODE_API_MODULE(detection, init);

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -8,6 +8,49 @@
 #define OBJECT_ITEM_SERIAL_NUMBER "serialNumber"
 #define OBJECT_ITEM_DEVICE_ADDRESS "deviceAddress"
 
+Detection::~Detection()
+{
+}
+
+Napi::Value Detection::StartMonitoring(const Napi::CallbackInfo &args)
+{
+	Napi::Env env = args.Env();
+
+	if (args.Length() == 0)
+	{
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+		return env.Null();
+	}
+
+	// callback
+	if (!args[0].IsFunction())
+	{
+		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
+		return env.Null();
+	}
+
+	if (!Start(env, args[0].As<Napi::Function>()))
+	{
+		Napi::Error::New(args.Env(), "Failed to start monitoring").ThrowAsJavaScriptException();
+		return env.Null();
+	}
+
+	return env.Null();
+}
+
+void Detection::StopMonitoring(const Napi::CallbackInfo &args)
+{
+	Stop();
+}
+
+Napi::Value Detection::IsMonitoring(const Napi::CallbackInfo &args)
+{
+	Napi::Env env = args.Env();
+
+	bool isRunning = IsRunning();
+	return Napi::Boolean::From(env, isRunning);
+}
+
 Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultItem_t> it)
 {
 	Napi::Object item = Napi::Object::New(env);
@@ -184,52 +227,9 @@ Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultI
 // 	delete req;
 // }
 
-Napi::Value StartMonitoring(const Napi::CallbackInfo &args)
-{
-	Napi::Env env = args.Env();
-
-	if (args.Length() == 0)
-	{
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	// callback
-	if (!args[0].IsFunction())
-	{
-		Napi::TypeError::New(env, "First argument must be a function").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	if (!Start(env, args[0].As<Napi::Function>()))
-	{
-		Napi::Error::New(args.Env(), "Failed to start monitoring").ThrowAsJavaScriptException();
-		return env.Null();
-	}
-
-	return env.Null();
-}
-
-void StopMonitoring(const Napi::CallbackInfo &args)
-{
-	Stop();
-}
-
-Napi::Value IsMonitoring(const Napi::CallbackInfo &args)
-{
-	Napi::Env env = args.Env();
-
-	bool isRunning = IsRunning();
-	return Napi::Boolean::From(env, isRunning);
-}
-
 Napi::Object init(Napi::Env env, Napi::Object exports)
 {
-	// exports.Set(Napi::String::New(env, "find"), Napi::Function::New(env, Find));
-	exports.Set(Napi::String::New(env, "startMonitoring"), Napi::Function::New(env, StartMonitoring));
-	exports.Set(Napi::String::New(env, "stopMonitoring"), Napi::Function::New(env, StopMonitoring));
-	exports.Set(Napi::String::New(env, "isMonitoring"), Napi::Function::New(env, IsMonitoring));
-	// InitDetection();
+	InitializeDetection(env, exports);
 	return exports;
 }
 

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -35,6 +35,8 @@ Napi::Value Detection::StartMonitoring(const Napi::CallbackInfo &args)
 		return env.Null();
 	}
 
+	// TODO - register a napi_add_env_cleanup_hook ?
+
 	return env.Null();
 }
 

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -263,12 +263,23 @@ void NotifyRemoved(ListResultItem_t *it)
 
 void StartMonitoring(const Napi::CallbackInfo &args)
 {
-	Start();
+	if (!Start())
+	{
+		Napi::Error::New(args.Env(), "Failed to start monitoring").ThrowAsJavaScriptException();
+	}
 }
 
 void StopMonitoring(const Napi::CallbackInfo &args)
 {
 	Stop();
+}
+
+Napi::Value IsMonitoring(const Napi::CallbackInfo &args)
+{
+	Napi::Env env = args.Env();
+
+	bool isRunning = IsRunning();
+	return Napi::Boolean::From(env, isRunning);
 }
 
 Napi::Object init(Napi::Env env, Napi::Object exports)
@@ -278,7 +289,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "registerRemoved"), Napi::Function::New(env, RegisterRemoved));
 	exports.Set(Napi::String::New(env, "startMonitoring"), Napi::Function::New(env, StartMonitoring));
 	exports.Set(Napi::String::New(env, "stopMonitoring"), Napi::Function::New(env, StopMonitoring));
-	InitDetection();
+	exports.Set(Napi::String::New(env, "isMonitoring"), Napi::Function::New(env, IsMonitoring));
+	// InitDetection();
 	return exports;
 }
 

--- a/src/detection.cpp
+++ b/src/detection.cpp
@@ -98,6 +98,54 @@ void NotifyRemoved(ListResultItem_t *it)
 	}
 }
 
+// class FindWorker : public Napi::AsyncWorker
+// {
+// public:
+// 	FindWorker(
+// 		Napi::Env &env,
+// 		int vid,
+// 		int pid)
+// 		: AsyncWorker(env),
+// 		  deferred(Napi::Promise::Deferred::New(env)),
+// 		  vid(vid),
+// 		  pid(pid)
+// 	{
+// 	}
+
+// 	~FindWorker()
+// 	{
+// 	}
+
+// 	void Execute()
+// 	{
+// 		std::string err = DoCompress(this->props);
+// 		if (!err.empty())
+// 		{
+// 			SetError(err);
+// 		}
+// 	}
+
+// 	void OnOK()
+// 	{
+// 		deferred.Resolve(CompressResult(Env(), this->dstBuffer.Value(), this->props));
+// 	}
+
+// 	void OnError(Napi::Error const &error)
+// 	{
+// 		deferred.Reject(error.Value());
+// 	}
+
+// 	Napi::Promise GetPromise() const
+// 	{
+// 		return deferred.Promise();
+// 	}
+
+// private:
+// 	Napi::Promise::Deferred deferred;
+// 	int vid;
+// 	int pid;
+// };
+
 // void Find(const Napi::CallbackInfo &args)
 // {
 // 	Napi::HandleScope scope(env);
@@ -112,7 +160,7 @@ void NotifyRemoved(ListResultItem_t *it)
 // 		return env.Null();
 // 	}
 
-// 	if (args.Length() == 3)
+// 	if (args.Length() >= 3)
 // 	{
 // 		if (args[0].IsNumber() && args[1].IsNumber())
 // 		{
@@ -159,15 +207,15 @@ void NotifyRemoved(ListResultItem_t *it)
 // 		callback = args[0].As<Napi::Function>();
 // 	}
 
-// 	ListBaton *baton = new ListBaton();
-// 	strcpy(baton->errorString, "");
-// 	baton->callback = new Napi::FunctionReference(callback);
-// 	baton->vid = vid;
-// 	baton->pid = pid;
+// 	// ListBaton *baton = new ListBaton();
+// 	// strcpy(baton->errorString, "");
+// 	// baton->callback = new Napi::FunctionReference(callback);
+// 	// baton->vid = vid;
+// 	// baton->pid = pid;
 
-// 	uv_work_t *req = new uv_work_t();
-// 	req->data = baton;
-// 	uv_queue_work(uv_default_loop(), req, EIO_Find, (uv_after_work_cb)EIO_AfterFind);
+// 	// uv_work_t *req = new uv_work_t();
+// 	// req->data = baton;
+// 	// uv_queue_work(uv_default_loop(), req, EIO_Find, (uv_after_work_cb)EIO_AfterFind);
 // }
 
 // void EIO_AfterFind(uv_work_t *req)

--- a/src/detection.h
+++ b/src/detection.h
@@ -6,8 +6,6 @@
 #include <list>
 #include <string>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "deviceList.h"
 

--- a/src/detection.h
+++ b/src/detection.h
@@ -26,8 +26,12 @@ public:
 
 	Napi::Value FindDevices(const Napi::CallbackInfo &args);
 
+	void DeviceAdded(const std::shared_ptr<ListResultItem_t> item);
+	void DeviceRemoved(const std::shared_ptr<ListResultItem_t> item);
+
 protected:
 	DeviceMap deviceMap;
+	Napi::ThreadSafeFunction notify_func;
 };
 
 // void EIO_Find(uv_work_t *req);

--- a/src/detection.h
+++ b/src/detection.h
@@ -3,7 +3,6 @@
 #define _USB_DETECTION_H
 
 #include <napi.h>
-// #include <uv.h> // TODO - this NEEDS to be removed for napi to work..
 #include <list>
 #include <string>
 #include <stdio.h>
@@ -15,8 +14,10 @@
 // void EIO_Find(uv_work_t *req);
 // void InitDetection();
 bool IsRunning();
-bool Start();
+bool Start(const Napi::Env &env, const Napi::Function &callback);
 void Stop();
+
+Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultItem_t> it);
 
 struct ListBaton
 {

--- a/src/detection.h
+++ b/src/detection.h
@@ -29,9 +29,6 @@ public:
 	int pid;
 };
 
-void NotifyAdded(ListResultItem_t *it);
-void NotifyRemoved(ListResultItem_t *it);
-
 #endif
 
 #ifdef DEBUG

--- a/src/detection.h
+++ b/src/detection.h
@@ -3,7 +3,7 @@
 #define _USB_DETECTION_H
 
 #include <napi.h>
-#include <uv.h> // TODO - this NEEDS to be removed for napi to work..
+// #include <uv.h> // TODO - this NEEDS to be removed for napi to work..
 #include <list>
 #include <string>
 #include <stdio.h>
@@ -12,9 +12,10 @@
 
 #include "deviceList.h"
 
-void EIO_Find(uv_work_t *req);
-void InitDetection();
-void Start();
+// void EIO_Find(uv_work_t *req);
+// void InitDetection();
+bool IsRunning();
+bool Start();
 void Stop();
 
 struct ListBaton

--- a/src/detection.h
+++ b/src/detection.h
@@ -3,50 +3,41 @@
 #define _USB_DETECTION_H
 
 #include <napi.h>
-#include <uv.h>
-#include <v8.h>
-#include <uv.h>
+#include <uv.h> // TODO - this NEEDS to be removed for napi to work..
 #include <list>
 #include <string>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <napi.h>
-#include <uv.h>
 
 #include "deviceList.h"
 
-void Find(const Napi::CallbackInfo& args);
-void EIO_Find(uv_work_t* req);
-void EIO_AfterFind(uv_work_t* req);
+void EIO_Find(uv_work_t *req);
 void InitDetection();
-void StartMonitoring(const Napi::CallbackInfo& args);
 void Start();
-void StopMonitoring(const Napi::CallbackInfo& args);
 void Stop();
 
-
-struct ListBaton {
-	public:
-		//v8::Persistent<v8::Function> callback;
-		Napi::FunctionReference* callback;
-		std::list<ListResultItem_t*> results;
-		char errorString[1024];
-		int vid;
-		int pid;
+struct ListBaton
+{
+public:
+	Napi::FunctionReference *callback;
+	std::list<ListResultItem_t *> results;
+	char errorString[1024];
+	int vid;
+	int pid;
 };
 
-void RegisterAdded(const Napi::CallbackInfo& args);
-void NotifyAdded(ListResultItem_t* it);
-void RegisterRemoved(const Napi::CallbackInfo& args);
-void NotifyRemoved(ListResultItem_t* it);
+void NotifyAdded(ListResultItem_t *it);
+void NotifyRemoved(ListResultItem_t *it);
 
 #endif
 
 #ifdef DEBUG
-  #define DEBUG_HEADER fprintf(stderr, "node-usb-detection [%s:%s() %d]: ", __FILE__, __FUNCTION__, __LINE__);
-  #define DEBUG_FOOTER fprintf(stderr, "\n");
-  #define DEBUG_LOG(...) DEBUG_HEADER fprintf(stderr, __VA_ARGS__); DEBUG_FOOTER
+#define DEBUG_HEADER fprintf(stderr, "node-usb-detection [%s:%s() %d]: ", __FILE__, __FUNCTION__, __LINE__);
+#define DEBUG_FOOTER fprintf(stderr, "\n");
+#define DEBUG_LOG(...)                         \
+	DEBUG_HEADER fprintf(stderr, __VA_ARGS__); \
+	DEBUG_FOOTER
 #else
-  #define DEBUG_LOG(...)
+#define DEBUG_LOG(...)
 #endif

--- a/src/detection.h
+++ b/src/detection.h
@@ -2,7 +2,8 @@
 #ifndef _USB_DETECTION_H
 #define _USB_DETECTION_H
 
-#include <node.h>
+#include <napi.h>
+#include <uv.h>
 #include <v8.h>
 #include <uv.h>
 #include <list>
@@ -10,33 +11,34 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <nan.h>
+#include <napi.h>
+#include <uv.h>
 
 #include "deviceList.h"
 
-void Find(const Nan::FunctionCallbackInfo<v8::Value>& args);
+void Find(const Napi::CallbackInfo& args);
 void EIO_Find(uv_work_t* req);
 void EIO_AfterFind(uv_work_t* req);
 void InitDetection();
-void StartMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args);
+void StartMonitoring(const Napi::CallbackInfo& args);
 void Start();
-void StopMonitoring(const Nan::FunctionCallbackInfo<v8::Value>& args);
+void StopMonitoring(const Napi::CallbackInfo& args);
 void Stop();
 
 
 struct ListBaton {
 	public:
 		//v8::Persistent<v8::Function> callback;
-		Nan::Callback* callback;
+		Napi::FunctionReference* callback;
 		std::list<ListResultItem_t*> results;
 		char errorString[1024];
 		int vid;
 		int pid;
 };
 
-void RegisterAdded(const Nan::FunctionCallbackInfo<v8::Value>& args);
+void RegisterAdded(const Napi::CallbackInfo& args);
 void NotifyAdded(ListResultItem_t* it);
-void RegisterRemoved(const Nan::FunctionCallbackInfo<v8::Value>& args);
+void RegisterRemoved(const Napi::CallbackInfo& args);
 void NotifyRemoved(ListResultItem_t* it);
 
 #endif

--- a/src/detection.h
+++ b/src/detection.h
@@ -11,11 +11,23 @@
 
 #include "deviceList.h"
 
+void InitializeDetection(Napi::Env &env, Napi::Object &target);
+
+class Detection
+{
+public:
+	~Detection();
+
+	virtual bool IsRunning() = 0;
+	virtual bool Start(const Napi::Env &env, const Napi::Function &callback) = 0;
+	virtual void Stop() = 0;
+
+	Napi::Value StartMonitoring(const Napi::CallbackInfo &args);
+	void StopMonitoring(const Napi::CallbackInfo &args);
+	Napi::Value IsMonitoring(const Napi::CallbackInfo &args);
+};
+
 // void EIO_Find(uv_work_t *req);
-// void InitDetection();
-bool IsRunning();
-bool Start(const Napi::Env &env, const Napi::Function &callback);
-void Stop();
 
 Napi::Value DeviceItemToObject(const Napi::Env &env, std::shared_ptr<ListResultItem_t> it);
 

--- a/src/detection.h
+++ b/src/detection.h
@@ -25,6 +25,11 @@ public:
 	Napi::Value StartMonitoring(const Napi::CallbackInfo &args);
 	void StopMonitoring(const Napi::CallbackInfo &args);
 	Napi::Value IsMonitoring(const Napi::CallbackInfo &args);
+
+	Napi::Value FindDevices(const Napi::CallbackInfo &args);
+
+protected:
+	DeviceMap deviceMap;
 };
 
 // void EIO_Find(uv_work_t *req);

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -43,8 +43,6 @@ public:
 										  });
 
 		target.Set("Detection", ctor);
-		// constructor = Napi::Persistent(ctor);
-		// constructor.SuppressDestruct();
 	}
 
 	bool IsRunning()
@@ -239,40 +237,21 @@ private:
 			dev = udev_device_new_from_syspath(udevHandle, path);
 
 			/* usb_device_get_devnode() returns the path to the device node
-		     itself in /dev. */
-			if (udev_device_get_devnode(dev) == NULL || udev_device_get_sysattr_value(dev, "idVendor") == NULL)
+			 itself in /dev. */
+			if (udev_device_get_devnode(dev) != nullptr && udev_device_get_sysattr_value(dev, "idVendor") != nullptr)
 			{
-				continue;
+				/* From here, we can call get_sysattr_value() for each file
+				in the device's /sys entry. The strings passed into these
+				functions (idProduct, idVendor, serial, etc.) correspond
+				directly to the files in the /sys directory which
+				represents the USB device. Note that USB strings are
+				Unicode, UCS2 encoded, but the strings returned from
+				udev_device_get_sysattr_value() are UTF-8 encoded. */
+
+				auto item = GetProperties(dev);
+
+				deviceMap.addItem(udev_device_get_devnode(dev), item);
 			}
-
-			/* From here, we can call get_sysattr_value() for each file
-		     in the device's /sys entry. The strings passed into these
-		     functions (idProduct, idVendor, serial, etc.) correspond
-		     directly to the files in the /sys directory which
-		     represents the USB device. Note that USB strings are
-		     Unicode, UCS2 encoded, but the strings returned from
-		     udev_device_get_sysattr_value() are UTF-8 encoded. */
-
-			// ListResultItem_t *item = new ListResultItem_t();
-			// item->vendorId = strtol(udev_device_get_sysattr_value(dev, "idVendor"), NULL, 16);
-			// item->productId = strtol(udev_device_get_sysattr_value(dev, "idProduct"), NULL, 16);
-			// if (udev_device_get_sysattr_value(dev, "product") != NULL)
-			// {
-			// 	item->deviceName = udev_device_get_sysattr_value(dev, "product");
-			// }
-			// if (udev_device_get_sysattr_value(dev, "manufacturer") != NULL)
-			// {
-			// 	item->manufacturer = udev_device_get_sysattr_value(dev, "manufacturer");
-			// }
-			// if (udev_device_get_sysattr_value(dev, "serial") != NULL)
-			// {
-			// 	item->serialNumber = udev_device_get_sysattr_value(dev, "serial");
-			// }
-			// item->deviceAddress = 0;
-			// item->locationId = 0;
-			auto item = GetProperties(dev);
-
-			deviceMap.addItem(udev_device_get_devnode(dev), item);
 
 			udev_device_unref(dev);
 		}

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -1,12 +1,11 @@
 #include <libudev.h>
 #include <poll.h>
+#include <thread>
 
 #include "detection.h"
 #include "deviceList.h"
 
 using namespace std;
-
-
 
 /**********************************
  * Local defines
@@ -20,34 +19,32 @@ using namespace std;
 #define DEVICE_PROPERTY_SERIAL "ID_SERIAL_SHORT"
 #define DEVICE_PROPERTY_VENDOR "ID_VENDOR"
 
-
 /**********************************
  * Local typedefs
  **********************************/
 
-
-
 /**********************************
  * Local Variables
  **********************************/
-static ListResultItem_t* currentItem;
+static ListResultItem_t *currentItem;
 static bool isAdded;
 
 static udev *udev;
 static udev_enumerate *enumerate;
 static udev_list_entry *devices, *dev_list_entry;
-static udev_device *dev;
+
+std::thread poll_thread;
 
 static udev_monitor *mon;
 static int fd;
 
-static uv_work_t work_req;
-static uv_signal_t term_signal;
-static uv_signal_t int_signal;
+// static uv_work_t work_req;
+// static uv_signal_t term_signal;
+// static uv_signal_t int_signal;
 
-static uv_async_t async_handler;
-static uv_mutex_t notify_mutex;
-static uv_cond_t notifyDeviceHandled;
+// static uv_async_t async_handler;
+// static uv_mutex_t notify_mutex;
+// static uv_cond_t notifyDeviceHandled;
 
 static bool deviceHandled = true;
 
@@ -60,145 +57,198 @@ static void BuildInitialDeviceList();
 
 static void WaitForDeviceHandled();
 static void SignalDeviceHandled();
-static void cbTerminate(uv_signal_t *handle, int signum);
-static void cbWork(uv_work_t *req);
-static void cbAfter(uv_work_t *req, int status);
-static void cbAsync(uv_async_t *handle);
+// static void cbTerminate(uv_signal_t *handle, int signum);
+static void cbWork();
+// static void cbAfter(uv_work_t *req, int status);
+// static void cbAsync(uv_async_t *handle);
 
 /**********************************
  * Public Functions
  **********************************/
-void Start() {
-	if(isRunning) {
-		return;
+
+bool IsRunning()
+{
+	return isRunning;
+}
+
+bool Start()
+{
+	if (isRunning)
+	{
+		return true;
 	}
 
 	isRunning = true;
 
-	uv_mutex_init(&notify_mutex);
-	uv_async_init(uv_default_loop(), &async_handler, cbAsync);
-	uv_signal_init(uv_default_loop(), &term_signal);
-	uv_signal_init(uv_default_loop(), &int_signal);
-	uv_cond_init(&notifyDeviceHandled);
-
-	uv_queue_work(uv_default_loop(), &work_req, cbWork, cbAfter);
-}
-
-void Stop() {
-	if(!isRunning) {
-		return;
-	}
-
-	isRunning = false;
-
-	uv_mutex_destroy(&notify_mutex);
-	uv_signal_stop(&int_signal);
-	uv_signal_stop(&term_signal);
-	uv_close((uv_handle_t *) &async_handler, NULL);
-	uv_cond_destroy(&notifyDeviceHandled);
-
-	udev_monitor_unref(mon);
-	udev_unref(udev);
-}
-
-void InitDetection() {
 	/* Create the udev object */
 	udev = udev_new();
 	if (!udev)
 	{
 		printf("Can't create udev\n");
-		return;
+		isRunning = false;
+		return false;
 	}
 
 	/* Set up a monitor to monitor devices */
 	mon = udev_monitor_new_from_netlink(udev, "udev");
+	if (!mon)
+	{
+		printf("Can't create udev monitor\n");
+		udev_unref(udev);
+		isRunning = false;
+		return false;
+	}
+
 	udev_monitor_enable_receiving(mon);
 
 	/* Get the file descriptor (fd) for the monitor.
 	   This fd will get passed to select() */
 	fd = udev_monitor_get_fd(mon);
 
+	// uv_mutex_init(&notify_mutex);
+	// uv_async_init(uv_default_loop(), &async_handler, cbAsync);
+	// uv_signal_init(uv_default_loop(), &term_signal);
+	// uv_signal_init(uv_default_loop(), &int_signal);
+	// uv_cond_init(&notifyDeviceHandled);
+
+	// uv_queue_work(uv_default_loop(), &work_req, cbWork, cbAfter);
+
+	poll_thread = std::thread(cbWork);
+
 	BuildInitialDeviceList();
+
+	return true;
 }
 
+void Stop()
+{
+	if (!isRunning)
+	{
+		return;
+	}
 
-void EIO_Find(uv_work_t* req) {
-	ListBaton* data = static_cast<ListBaton*>(req->data);
+	isRunning = false;
 
-	CreateFilteredList(&data->results, data->vid, data->pid);
+	// uv_mutex_destroy(&notify_mutex);
+	// uv_signal_stop(&int_signal);
+	// uv_signal_stop(&term_signal);
+	// uv_close((uv_handle_t *)&async_handler, NULL);
+	// uv_cond_destroy(&notifyDeviceHandled);
+
+	udev_monitor_unref(mon);
+	udev_unref(udev);
 }
+
+// void InitDetection()
+// {
+// 	/* Create the udev object */
+// 	udev = udev_new();
+// 	if (!udev)
+// 	{
+// 		printf("Can't create udev\n");
+// 		return;
+// 	}
+
+// 	/* Set up a monitor to monitor devices */
+// 	mon = udev_monitor_new_from_netlink(udev, "udev");
+// 	udev_monitor_enable_receiving(mon);
+
+// 	/* Get the file descriptor (fd) for the monitor.
+// 	   This fd will get passed to select() */
+// 	fd = udev_monitor_get_fd(mon);
+
+// 	BuildInitialDeviceList();
+// }
+
+// void EIO_Find(uv_work_t* req) {
+// 	ListBaton* data = static_cast<ListBaton*>(req->data);
+
+// 	CreateFilteredList(&data->results, data->vid, data->pid);
+// }
 
 /**********************************
  * Local Functions
  **********************************/
-static void WaitForDeviceHandled() {
-	uv_mutex_lock(&notify_mutex);
-	if(deviceHandled == false) {
-		uv_cond_wait(&notifyDeviceHandled, &notify_mutex);
-	}
-	deviceHandled = false;
-	uv_mutex_unlock(&notify_mutex);
+static void WaitForDeviceHandled()
+{
+	// uv_mutex_lock(&notify_mutex);
+	// if (deviceHandled == false)
+	// {
+	// 	uv_cond_wait(&notifyDeviceHandled, &notify_mutex);
+	// }
+	// deviceHandled = false;
+	// uv_mutex_unlock(&notify_mutex);
 }
 
-static void SignalDeviceHandled() {
-	uv_mutex_lock(&notify_mutex);
-	deviceHandled = true;
-	uv_cond_signal(&notifyDeviceHandled);
-	uv_mutex_unlock(&notify_mutex);
+static void SignalDeviceHandled()
+{
+	// uv_mutex_lock(&notify_mutex);
+	// deviceHandled = true;
+	// uv_cond_signal(&notifyDeviceHandled);
+	// uv_mutex_unlock(&notify_mutex);
 }
 
-static ListResultItem_t* GetProperties(struct udev_device* dev, ListResultItem_t* item) {
-	struct udev_list_entry* sysattrs;
-	struct udev_list_entry* entry;
+static ListResultItem_t *GetProperties(struct udev_device *dev, ListResultItem_t *item)
+{
+	struct udev_list_entry *sysattrs;
+	struct udev_list_entry *entry;
 	sysattrs = udev_device_get_properties_list_entry(dev);
-	udev_list_entry_foreach(entry, sysattrs) {
+	udev_list_entry_foreach(entry, sysattrs)
+	{
 		const char *name, *value;
 		name = udev_list_entry_get_name(entry);
 		value = udev_list_entry_get_value(entry);
 
-		if(strcmp(name, DEVICE_PROPERTY_NAME) == 0) {
+		if (strcmp(name, DEVICE_PROPERTY_NAME) == 0)
+		{
 			item->deviceName = value;
 		}
-		else if(strcmp(name, DEVICE_PROPERTY_SERIAL) == 0) {
+		else if (strcmp(name, DEVICE_PROPERTY_SERIAL) == 0)
+		{
 			item->serialNumber = value;
 		}
-		else if(strcmp(name, DEVICE_PROPERTY_VENDOR) == 0) {
+		else if (strcmp(name, DEVICE_PROPERTY_VENDOR) == 0)
+		{
 			item->manufacturer = value;
 		}
 	}
-	item->vendorId = strtol(udev_device_get_sysattr_value(dev,"idVendor"), NULL, 16);
-	item->productId = strtol(udev_device_get_sysattr_value(dev,"idProduct"), NULL, 16);
+	item->vendorId = strtol(udev_device_get_sysattr_value(dev, "idVendor"), NULL, 16);
+	item->productId = strtol(udev_device_get_sysattr_value(dev, "idProduct"), NULL, 16);
 	item->deviceAddress = 0;
 	item->locationId = 0;
 
 	return item;
 }
 
-static void DeviceAdded(struct udev_device* dev) {
-	DeviceItem_t* item = new DeviceItem_t();
-	GetProperties(dev, &item->deviceParams);
+static void DeviceAdded(struct udev_device *dev)
+{
+	ListResultItem_t *item = new ListResultItem_t();
+	GetProperties(dev, item);
 
 	AddItemToList((char *)udev_device_get_devnode(dev), item);
 
-	currentItem = &item->deviceParams;
+	currentItem = item;
 	isAdded = true;
 
-	uv_async_send(&async_handler);
+	// uv_async_send(&async_handler);
 }
 
-static void DeviceRemoved(struct udev_device* dev) {
-	ListResultItem_t* item = NULL;
+static void DeviceRemoved(struct udev_device *dev)
+{
+	ListResultItem_t *item = NULL;
 
-	if(IsItemAlreadyStored((char *)udev_device_get_devnode(dev))) {
-		DeviceItem_t* deviceItem = GetItemFromList((char *)udev_device_get_devnode(dev));
-		if(deviceItem) {
-			item = CopyElement(&deviceItem->deviceParams);
+	if (IsItemAlreadyStored((char *)udev_device_get_devnode(dev)))
+	{
+		ListResultItem_t *deviceItem = PopItemFromList((char *)udev_device_get_devnode(dev));
+		if (deviceItem)
+		{
+			item = CopyElement(deviceItem);
 		}
-		RemoveItemFromList(deviceItem);
 		delete deviceItem;
 	}
 
-	if(item == NULL) {
+	if (item == NULL)
+	{
 		item = new ListResultItem_t();
 		GetProperties(dev, item);
 	}
@@ -206,34 +256,44 @@ static void DeviceRemoved(struct udev_device* dev) {
 	currentItem = item;
 	isAdded = false;
 
-	uv_async_send(&async_handler);
+	// uv_async_send(&async_handler);
 }
 
-
-static void cbWork(uv_work_t *req) {
+static void cbWork()
+{
 	// We have this check in case we `Stop` before this thread starts,
 	// otherwise the process will hang
-	if(!isRunning) {
+	if (!isRunning)
+	{
 		return;
 	}
 
-	uv_signal_start(&int_signal, cbTerminate, SIGINT);
-	uv_signal_start(&term_signal, cbTerminate, SIGTERM);
+	// uv_signal_start(&int_signal, cbTerminate, SIGINT);
+	// uv_signal_start(&term_signal, cbTerminate, SIGTERM);
+
+	udev_device *dev;
 
 	pollfd fds = {fd, POLLIN, 0};
-	while (isRunning) {
+	while (isRunning)
+	{
 		int ret = poll(&fds, 1, 100);
-		if (!ret) continue;
-		if (ret < 0) break;
+		if (!ret)
+			continue;
+		if (ret < 0)
+			break;
 
 		dev = udev_monitor_receive_device(mon);
-		if (dev) {
-			if(udev_device_get_devtype(dev) && strcmp(udev_device_get_devtype(dev), DEVICE_TYPE_DEVICE) == 0) {
-				if(strcmp(udev_device_get_action(dev), DEVICE_ACTION_ADDED) == 0) {
+		if (dev)
+		{
+			if (udev_device_get_devtype(dev) && strcmp(udev_device_get_devtype(dev), DEVICE_TYPE_DEVICE) == 0)
+			{
+				if (strcmp(udev_device_get_action(dev), DEVICE_ACTION_ADDED) == 0)
+				{
 					WaitForDeviceHandled();
 					DeviceAdded(dev);
 				}
-				else if(strcmp(udev_device_get_action(dev), DEVICE_ACTION_REMOVED) == 0) {
+				else if (strcmp(udev_device_get_action(dev), DEVICE_ACTION_REMOVED) == 0)
+				{
 					WaitForDeviceHandled();
 					DeviceRemoved(dev);
 				}
@@ -241,39 +301,49 @@ static void cbWork(uv_work_t *req) {
 			udev_device_unref(dev);
 		}
 	}
-}
 
-static void cbAfter(uv_work_t *req, int status) {
 	Stop();
 }
 
-static void cbAsync(uv_async_t *handle) {
-	if(!isRunning) {
-		return;
-	}
+// static void cbAfter(uv_work_t *req, int status)
+// {
+// 	Stop();
+// }
 
-	if (isAdded) {
-		NotifyAdded(currentItem);
-	}
-	else {
-		NotifyRemoved(currentItem);
-	}
+// static void cbAsync(uv_async_t *handle)
+// {
+// 	if (!isRunning)
+// 	{
+// 		return;
+// 	}
 
-	// Delete Item in case of removal
-	if(isAdded == false) {
-		delete currentItem;
-	}
+// 	if (isAdded)
+// 	{
+// 		NotifyAdded(currentItem);
+// 	}
+// 	else
+// 	{
+// 		NotifyRemoved(currentItem);
+// 	}
 
-	SignalDeviceHandled();
-}
+// 	// Delete Item in case of removal
+// 	if (isAdded == false)
+// 	{
+// 		delete currentItem;
+// 	}
 
+// 	SignalDeviceHandled();
+// }
 
-static void cbTerminate(uv_signal_t *handle, int signum) {
-	Stop();
-}
+// static void cbTerminate(uv_signal_t *handle, int signum)
+// {
+// 	Stop();
+// }
 
+static void BuildInitialDeviceList()
+{
+	udev_device *dev;
 
-static void BuildInitialDeviceList() {
 	/* Create a list of the devices */
 	enumerate = udev_enumerate_new(udev);
 	udev_enumerate_scan_devices(enumerate);
@@ -283,7 +353,8 @@ static void BuildInitialDeviceList() {
 	   a loop. The loop will be executed for each member in
 	   devices, setting dev_list_entry to a list entry
 	   which contains the device's path in /sys. */
-	udev_list_entry_foreach(dev_list_entry, devices) {
+	udev_list_entry_foreach(dev_list_entry, devices)
+	{
 		const char *path;
 
 		/* Get the filename of the /sys entry for the device
@@ -293,7 +364,8 @@ static void BuildInitialDeviceList() {
 
 		/* usb_device_get_devnode() returns the path to the device node
 		   itself in /dev. */
-		if(udev_device_get_devnode(dev) == NULL || udev_device_get_sysattr_value(dev,"idVendor") == NULL) {
+		if (udev_device_get_devnode(dev) == NULL || udev_device_get_sysattr_value(dev, "idVendor") == NULL)
+		{
 			continue;
 		}
 
@@ -305,22 +377,23 @@ static void BuildInitialDeviceList() {
 		   Unicode, UCS2 encoded, but the strings returned from
 		   udev_device_get_sysattr_value() are UTF-8 encoded. */
 
-		DeviceItem_t* item = new DeviceItem_t();
-		item->deviceParams.vendorId = strtol (udev_device_get_sysattr_value(dev,"idVendor"), NULL, 16);
-		item->deviceParams.productId = strtol (udev_device_get_sysattr_value(dev,"idProduct"), NULL, 16);
-		if(udev_device_get_sysattr_value(dev,"product") != NULL) {
-			item->deviceParams.deviceName = udev_device_get_sysattr_value(dev,"product");
+		ListResultItem_t *item = new ListResultItem_t();
+		item->vendorId = strtol(udev_device_get_sysattr_value(dev, "idVendor"), NULL, 16);
+		item->productId = strtol(udev_device_get_sysattr_value(dev, "idProduct"), NULL, 16);
+		if (udev_device_get_sysattr_value(dev, "product") != NULL)
+		{
+			item->deviceName = udev_device_get_sysattr_value(dev, "product");
 		}
-		if(udev_device_get_sysattr_value(dev,"manufacturer") != NULL) {
-			item->deviceParams.manufacturer = udev_device_get_sysattr_value(dev,"manufacturer");
+		if (udev_device_get_sysattr_value(dev, "manufacturer") != NULL)
+		{
+			item->manufacturer = udev_device_get_sysattr_value(dev, "manufacturer");
 		}
-		if(udev_device_get_sysattr_value(dev,"serial") != NULL) {
-			item->deviceParams.serialNumber = udev_device_get_sysattr_value(dev, "serial");
+		if (udev_device_get_sysattr_value(dev, "serial") != NULL)
+		{
+			item->serialNumber = udev_device_get_sysattr_value(dev, "serial");
 		}
-		item->deviceParams.deviceAddress = 0;
-		item->deviceParams.locationId = 0;
-
-		item->deviceState = DeviceState_Connect;
+		item->deviceAddress = 0;
+		item->locationId = 0;
 
 		AddItemToList((char *)udev_device_get_devnode(dev), item);
 

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -62,6 +62,7 @@ public:
 											  InstanceMethod("isMonitoring", &Detection::IsMonitoring),
 											  InstanceMethod("startMonitoring", &Detection::StartMonitoring),
 											  InstanceMethod("stopMonitoring", &Detection::StopMonitoring),
+											  InstanceMethod("findDevices", &Detection::FindDevices),
 										  });
 
 		target.Set("Detection", ctor);
@@ -337,7 +338,6 @@ private:
 	udev_monitor *mon;
 	int fd;
 
-	DeviceMap deviceMap;
 	bool isRunning = false;
 };
 

--- a/src/detection_mac.cpp
+++ b/src/detection_mac.cpp
@@ -206,6 +206,7 @@ public:
 										  {
 											  NotificationDeviceItem *notifyItem = (NotificationDeviceItem *)item->data;
 											  FreeNotificationItem(notifyItem);
+											  delete notifyItem;
 										  }
 									  }
 

--- a/src/detection_mac.cpp
+++ b/src/detection_mac.cpp
@@ -1,6 +1,3 @@
-#include "detection.h"
-#include "deviceList.h"
-
 #include <CoreFoundation/CoreFoundation.h>
 
 #include <IOKit/IOKitLib.h>
@@ -10,59 +7,23 @@
 
 #include <sys/param.h>
 #include <poll.h>
+#include <thread>
 
-#include <uv.h>
+#include "detection.h"
+#include "deviceList.h"
 
-/**********************************
- * Local typedefs
- **********************************/
-typedef struct DeviceListItem
+struct NotificationDeviceItem
 {
 	io_object_t notification;
 	IOUSBDeviceInterface **deviceInterface;
-	ListResultItem_t *deviceItem;
-} stDeviceListItem;
-
-/**********************************
- * Local Variables
- **********************************/
-static ListResultItem_t *currentItem;
-static bool isAdded = false;
-static bool initialDeviceImport = true;
-
-static IONotificationPortRef gNotifyPort;
-static io_iterator_t gAddedIter;
-static CFRunLoopRef gRunLoop;
-
-static CFMutableDictionaryRef matchingDict;
-static CFRunLoopSourceRef runLoopSource;
-
-static uv_work_t work_req;
-static uv_signal_t term_signal;
-static uv_signal_t int_signal;
-
-static uv_async_t async_handler;
-static uv_mutex_t notify_mutex;
-static uv_cond_t notifyDeviceHandled;
-
-static bool deviceHandled = true;
-
-static bool isRunning = false;
+	std::shared_ptr<ListResultItem_t> deviceItem;
+	Detection *parent;
+};
 
 /**********************************
  * Local Helper Functions protoypes
  **********************************/
 
-static void WaitForDeviceHandled();
-static void SignalDeviceHandled();
-static void cbTerminate(uv_signal_t *handle, int signum);
-static void cbWork(uv_work_t *req);
-static void cbAfter(uv_work_t *req, int status);
-static void cbAsync(uv_async_t *handle);
-
-/**********************************
- * Public Functions
- **********************************/
 //================================================================================================
 //
 //  DeviceRemoved
@@ -72,39 +33,7 @@ static void cbAsync(uv_async_t *handle);
 //  messages are defined in IOMessage.h.
 //
 //================================================================================================
-static void DeviceRemoved(void *refCon, io_service_t service, natural_t messageType, void *messageArgument)
-{
-	kern_return_t kr;
-	stDeviceListItem *deviceListItem = (stDeviceListItem *)refCon;
-	ListResultItem_t *deviceItem = deviceListItem->deviceItem;
-
-	if (messageType == kIOMessageServiceIsTerminated)
-	{
-		if (deviceListItem->deviceInterface)
-		{
-			kr = (*deviceListItem->deviceInterface)->Release(deviceListItem->deviceInterface);
-		}
-
-		kr = IOObjectRelease(deviceListItem->notification);
-
-		ListResultItem_t *item = NULL;
-		if (deviceItem)
-		{
-			item = CopyElement(deviceItem);
-			PopItemFromList(deviceItem);
-			delete deviceItem;
-		}
-		else
-		{
-			item = new ListResultItem_t();
-		}
-
-		WaitForDeviceHandled();
-		currentItem = item;
-		isAdded = false;
-		uv_async_send(&async_handler);
-	}
-}
+static void DeviceRemovedOuter(void *refCon, io_service_t service, natural_t messageType, void *messageArgument);
 
 //================================================================================================
 //
@@ -120,389 +49,407 @@ static void DeviceRemoved(void *refCon, io_service_t service, natural_t messageT
 //      this interest notification, we can grab the refCon and access our private data.
 //
 //================================================================================================
-static void DeviceAdded(void *refCon, io_iterator_t iterator)
+static void DeviceAddedOuter(void *refCon, io_iterator_t iterator);
+
+/**********************************
+ * Public Functions
+ **********************************/
+
+class MacDetection : public Detection, public Napi::ObjectWrap<MacDetection>
 {
-	kern_return_t kr;
-	io_service_t usbDevice;
-	IOCFPlugInInterface **plugInInterface = NULL;
-	SInt32 score;
-	HRESULT res;
-
-	while ((usbDevice = IOIteratorNext(iterator)))
+public:
+	MacDetection(const Napi::CallbackInfo &info)
+		: Napi::ObjectWrap<MacDetection>(info)
 	{
-		io_name_t deviceName;
-		CFStringRef deviceNameAsCFString;
-		UInt32 locationID;
-		UInt16 vendorId;
-		UInt16 productId;
-		UInt16 addr;
+	}
 
-		ListResultItem_t *deviceItem = new ListResultItem_t();
+	static void Initialize(Napi::Env &env, Napi::Object &target)
+	{
+		Napi::Function ctor = DefineClass(env, "Detection",
+										  {
+											  InstanceMethod("isMonitoring", &Detection::IsMonitoring),
+											  InstanceMethod("startMonitoring", &Detection::StartMonitoring),
+											  InstanceMethod("stopMonitoring", &Detection::StopMonitoring),
+											  InstanceMethod("findDevices", &Detection::FindDevices),
+										  });
 
-		// Get the USB device's name.
-		kr = IORegistryEntryGetName(usbDevice, deviceName);
-		if (KERN_SUCCESS != kr)
+		target.Set("Detection", ctor);
+		// constructor = Napi::Persistent(ctor);
+		// constructor.SuppressDestruct();
+	}
+
+	bool IsRunning()
+	{
+		return isRunning;
+	}
+	bool Start(const Napi::Env &env, const Napi::Function &callback)
+	{
+		if (isRunning)
 		{
-			deviceName[0] = '\0';
+			return true;
 		}
 
-		deviceNameAsCFString = CFStringCreateWithCString(kCFAllocatorDefault, deviceName, kCFStringEncodingASCII);
+		isRunning = true;
 
-		if (deviceNameAsCFString)
+		kern_return_t kr;
+
+		// Set up the matching criteria for the devices we're interested in. The matching criteria needs to follow
+		// the same rules as kernel drivers: mainly it needs to follow the USB Common Class Specification, pp. 6-7.
+		// See also Technical Q&A QA1076 "Tips on USB driver matching on Mac OS X"
+		// <http://developer.apple.com/qa/qa2001/qa1076.html>.
+		// One exception is that you can use the matching dictionary "as is", i.e. without adding any matching
+		// criteria to it and it will match every IOUSBDevice in the system. IOServiceAddMatchingNotification will
+		// consume this dictionary reference, so there is no need to release it later on.
+
+		// Interested in instances of class
+		// IOUSBDevice and its subclasses
+		matchingDict = IOServiceMatching(kIOUSBDeviceClassName);
+
+		if (matchingDict == NULL)
 		{
-			Boolean result;
-			char deviceName[MAXPATHLEN];
-
-			// Convert from a CFString to a C (NUL-terminated)
-			result = CFStringGetCString(deviceNameAsCFString,
-										deviceName,
-										sizeof(deviceName),
-										kCFStringEncodingUTF8);
-
-			if (result)
-			{
-				deviceItem->deviceName = deviceName;
-			}
-
-			CFRelease(deviceNameAsCFString);
+			DEBUG_LOG("IOServiceMatching returned NULL.\n");
 		}
 
-		CFStringRef manufacturerAsCFString = (CFStringRef)IORegistryEntrySearchCFProperty(
-			usbDevice,
-			kIOServicePlane,
-			CFSTR(kUSBVendorString),
-			kCFAllocatorDefault,
-			kIORegistryIterateRecursively);
+		// Create a notification port and add its run loop event source to our run loop
+		// This is how async notifications get set up.
 
-		if (manufacturerAsCFString)
-		{
-			Boolean result;
-			char manufacturer[MAXPATHLEN];
+		gNotifyPort = IONotificationPortCreate(kIOMasterPortDefault);
 
-			// Convert from a CFString to a C (NUL-terminated)
-			result = CFStringGetCString(
-				manufacturerAsCFString,
-				manufacturer,
-				sizeof(manufacturer),
-				kCFStringEncodingUTF8);
+		io_iterator_t gAddedIter;
 
-			if (result)
-			{
-				deviceItem->manufacturer = manufacturer;
-			}
-
-			CFRelease(manufacturerAsCFString);
-		}
-
-		CFStringRef serialNumberAsCFString = (CFStringRef)IORegistryEntrySearchCFProperty(
-			usbDevice,
-			kIOServicePlane,
-			CFSTR(kUSBSerialNumberString),
-			kCFAllocatorDefault,
-			kIORegistryIterateRecursively);
-
-		if (serialNumberAsCFString)
-		{
-			Boolean result;
-			char serialNumber[MAXPATHLEN];
-
-			// Convert from a CFString to a C (NUL-terminated)
-			result = CFStringGetCString(
-				serialNumberAsCFString,
-				serialNumber,
-				sizeof(serialNumber),
-				kCFStringEncodingUTF8);
-
-			if (result)
-			{
-				deviceItem->serialNumber = serialNumber;
-			}
-
-			CFRelease(serialNumberAsCFString);
-		}
-
-		// Now, get the locationID of this device. In order to do this, we need to create an IOUSBDeviceInterface
-		// for our device. This will create the necessary connections between our userland application and the
-		// kernel object for the USB Device.
-		kr = IOCreatePlugInInterfaceForService(usbDevice, kIOUSBDeviceUserClientTypeID, kIOCFPlugInInterfaceID, &plugInInterface, &score);
-
-		if ((kIOReturnSuccess != kr) || !plugInInterface)
-		{
-			DEBUG_LOG("IOCreatePlugInInterfaceForService returned 0x%08x.\n", kr);
-			continue;
-		}
-
-		stDeviceListItem *deviceListItem = new stDeviceListItem();
-
-		// Use the plugin interface to retrieve the device interface.
-		res = (*plugInInterface)->QueryInterface(plugInInterface, CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID), (LPVOID *)&deviceListItem->deviceInterface);
-
-		// Now done with the plugin interface.
-		(*plugInInterface)->Release(plugInInterface);
-
-		if (res || deviceListItem->deviceInterface == NULL)
-		{
-			DEBUG_LOG("QueryInterface returned %d.\n", (int)res);
-			continue;
-		}
-
-		// Now that we have the IOUSBDeviceInterface, we can call the routines in IOUSBLib.h.
-		// In this case, fetch the locationID. The locationID uniquely identifies the device
-		// and will remain the same, even across reboots, so long as the bus topology doesn't change.
-
-		kr = (*deviceListItem->deviceInterface)->GetLocationID(deviceListItem->deviceInterface, &locationID);
-		if (KERN_SUCCESS != kr)
-		{
-			DEBUG_LOG("GetLocationID returned 0x%08x.\n", kr);
-			continue;
-		}
-		deviceItem->locationId = locationID;
-
-		kr = (*deviceListItem->deviceInterface)->GetDeviceAddress(deviceListItem->deviceInterface, &addr);
-		if (KERN_SUCCESS != kr)
-		{
-			DEBUG_LOG("GetDeviceAddress returned 0x%08x.\n", kr);
-			continue;
-		}
-		deviceItem->deviceAddress = addr;
-
-		kr = (*deviceListItem->deviceInterface)->GetDeviceVendor(deviceListItem->deviceInterface, &vendorId);
-		if (KERN_SUCCESS != kr)
-		{
-			DEBUG_LOG("GetDeviceVendor returned 0x%08x.\n", kr);
-			continue;
-		}
-		deviceItem->vendorId = vendorId;
-
-		kr = (*deviceListItem->deviceInterface)->GetDeviceProduct(deviceListItem->deviceInterface, &productId);
-		if (KERN_SUCCESS != kr)
-		{
-			DEBUG_LOG("GetDeviceProduct returned 0x%08x.\n", kr);
-			continue;
-		}
-		deviceItem->productId = productId;
-
-		// Extract path name as unique key
-		io_string_t pathName;
-		IORegistryEntryGetPath(usbDevice, kIOServicePlane, pathName);
-		deviceNameAsCFString = CFStringCreateWithCString(kCFAllocatorDefault, pathName, kCFStringEncodingASCII);
-		char cPathName[MAXPATHLEN];
-
-		if (deviceNameAsCFString)
-		{
-			Boolean result;
-
-			// Convert from a CFString to a C (NUL-terminated)
-			result = CFStringGetCString(
-				deviceNameAsCFString,
-				cPathName,
-				sizeof(cPathName),
-				kCFStringEncodingUTF8);
-
-			CFRelease(deviceNameAsCFString);
-		}
-
-		AddItemToList(cPathName, deviceItem);
-		deviceListItem->deviceItem = deviceItem;
-
-		if (initialDeviceImport == false)
-		{
-			WaitForDeviceHandled();
-			currentItem = deviceItem;
-			isAdded = true;
-			uv_async_send(&async_handler);
-		}
-
-		// Register for an interest notification of this device being removed. Use a reference to our
-		// private data as the refCon which will be passed to the notification callback.
-		kr = IOServiceAddInterestNotification(
-			gNotifyPort,					// notifyPort
-			usbDevice,						// service
-			kIOGeneralInterest,				// interestType
-			DeviceRemoved,					// callback
-			deviceListItem,					// refCon
-			&(deviceListItem->notification) // notification
+		// Now set up a notification to be called when a device is first matched by I/O Kit.
+		kr = IOServiceAddMatchingNotification(
+			gNotifyPort,			   // notifyPort
+			kIOFirstMatchNotification, // notificationType
+			matchingDict,			   // matching
+			DeviceAddedOuter,		   // callback
+			this,					   // refCon
+			&gAddedIter				   // notification
 		);
 
 		if (KERN_SUCCESS != kr)
 		{
-			DEBUG_LOG("IOServiceAddInterestNotification returned 0x%08x.\n", kr);
+			DEBUG_LOG("IOServiceAddMatchingNotification returned 0x%08x.\n", kr);
 		}
 
-		// Done with this USB device; release the reference added by IOIteratorNext
-		kr = IOObjectRelease(usbDevice);
-	}
-}
+		// Iterate once to get already-present devices, skipping the notify
+		IterateFoundDevices(gAddedIter, false);
 
-void Start()
+		notify_func = Napi::ThreadSafeFunction::New(
+			env,
+			callback,		 // JavaScript function called asynchronously
+			"Resource Name", // Name
+			0,				 // Unlimited queue
+			1,				 // Only one thread will use this initially
+			[=](Napi::Env) { // Finalizer used to clean threads up
+				// Wait for end of the thread, if it wasnt the one to close up
+				if (poll_thread.joinable())
+				{
+					poll_thread.join();
+				}
+			});
+
+		poll_thread = std::thread([=]()
+								  {
+									  // We have this check in case we `Stop` before this thread starts,
+									  // otherwise the process will hang
+									  if (!isRunning)
+									  {
+										  return;
+									  }
+
+									  CFRunLoopSourceRef runLoopSource = IONotificationPortGetRunLoopSource(gNotifyPort);
+
+									  gRunLoop = CFRunLoopGetCurrent();
+									  CFRunLoopAddSource(gRunLoop, runLoopSource, kCFRunLoopDefaultMode);
+
+									  // Creating `gRunLoop` can take some cycles so we also need this second
+									  // `isRunning` check here because it happens at a future time
+									  if (isRunning)
+									  {
+										  // Start the run loop. Now we'll receive notifications.
+										  CFRunLoopRun();
+									  }
+
+									  // The `CFRunLoopRun` is a blocking call so we also need this second
+									  // `isRunning` check here because it happens at a future time
+									  if (isRunning)
+									  {
+										  // We should never get here while running
+										  DEBUG_LOG("Unexpectedly back from CFRunLoopRun()!\n");
+									  }
+
+									  notify_func.Release();
+								  });
+
+		return true;
+	}
+	void Stop()
+	{
+		if (isRunning)
+		{
+			isRunning = false;
+
+			if (gRunLoop)
+			{
+				CFRunLoopStop(gRunLoop);
+			}
+
+			poll_thread.join();
+		}
+	}
+
+	void IterateFoundDevices(io_iterator_t iterator, bool notify)
+	{
+		kern_return_t kr;
+		io_service_t usbDevice;
+		IOCFPlugInInterface **plugInInterface = NULL;
+		SInt32 score;
+		HRESULT res;
+
+		while ((usbDevice = IOIteratorNext(iterator)))
+		{
+			io_name_t deviceName;
+			CFStringRef deviceNameAsCFString;
+			UInt32 locationID;
+			UInt16 vendorId;
+			UInt16 productId;
+			UInt16 addr;
+
+			std::shared_ptr<ListResultItem_t> item(new ListResultItem_t);
+
+			// Get the USB device's name.
+			kr = IORegistryEntryGetName(usbDevice, deviceName);
+			if (KERN_SUCCESS != kr)
+			{
+				deviceName[0] = '\0';
+			}
+
+			deviceNameAsCFString = CFStringCreateWithCString(kCFAllocatorDefault, deviceName, kCFStringEncodingASCII);
+
+			if (deviceNameAsCFString)
+			{
+				Boolean result;
+				char deviceName[MAXPATHLEN];
+
+				// Convert from a CFString to a C (NUL-terminated)
+				result = CFStringGetCString(deviceNameAsCFString,
+											deviceName,
+											sizeof(deviceName),
+											kCFStringEncodingUTF8);
+
+				if (result)
+				{
+					item->deviceName = deviceName;
+				}
+
+				CFRelease(deviceNameAsCFString);
+			}
+
+			CFStringRef manufacturerAsCFString = (CFStringRef)IORegistryEntrySearchCFProperty(
+				usbDevice,
+				kIOServicePlane,
+				CFSTR(kUSBVendorString),
+				kCFAllocatorDefault,
+				kIORegistryIterateRecursively);
+
+			if (manufacturerAsCFString)
+			{
+				Boolean result;
+				char manufacturer[MAXPATHLEN];
+
+				// Convert from a CFString to a C (NUL-terminated)
+				result = CFStringGetCString(
+					manufacturerAsCFString,
+					manufacturer,
+					sizeof(manufacturer),
+					kCFStringEncodingUTF8);
+
+				if (result)
+				{
+					item->manufacturer = manufacturer;
+				}
+
+				CFRelease(manufacturerAsCFString);
+			}
+
+			CFStringRef serialNumberAsCFString = (CFStringRef)IORegistryEntrySearchCFProperty(
+				usbDevice,
+				kIOServicePlane,
+				CFSTR(kUSBSerialNumberString),
+				kCFAllocatorDefault,
+				kIORegistryIterateRecursively);
+
+			if (serialNumberAsCFString)
+			{
+				Boolean result;
+				char serialNumber[MAXPATHLEN];
+
+				// Convert from a CFString to a C (NUL-terminated)
+				result = CFStringGetCString(
+					serialNumberAsCFString,
+					serialNumber,
+					sizeof(serialNumber),
+					kCFStringEncodingUTF8);
+
+				if (result)
+				{
+					item->serialNumber = serialNumber;
+				}
+
+				CFRelease(serialNumberAsCFString);
+			}
+
+			// Now, get the locationID of this device. In order to do this, we need to create an IOUSBDeviceInterface
+			// for our device. This will create the necessary connections between our userland application and the
+			// kernel object for the USB Device.
+			kr = IOCreatePlugInInterfaceForService(usbDevice, kIOUSBDeviceUserClientTypeID, kIOCFPlugInInterfaceID, &plugInInterface, &score);
+
+			if ((kIOReturnSuccess != kr) || !plugInInterface)
+			{
+				DEBUG_LOG("IOCreatePlugInInterfaceForService returned 0x%08x.\n", kr);
+				continue;
+			}
+
+			NotificationDeviceItem *notificationItem = new NotificationDeviceItem();
+			notificationItem->parent = this;
+
+			// Use the plugin interface to retrieve the device interface.
+			res = (*plugInInterface)->QueryInterface(plugInInterface, CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID), (LPVOID *)&notificationItem->deviceInterface);
+
+			// Now done with the plugin interface.
+			(*plugInInterface)->Release(plugInInterface);
+
+			if (res || notificationItem->deviceInterface == NULL)
+			{
+				DEBUG_LOG("QueryInterface returned %d.\n", (int)res);
+				continue;
+			}
+
+			// Now that we have the IOUSBDeviceInterface, we can call the routines in IOUSBLib.h.
+			// In this case, fetch the locationID. The locationID uniquely identifies the device
+			// and will remain the same, even across reboots, so long as the bus topology doesn't change.
+
+			kr = (*notificationItem->deviceInterface)->GetLocationID(notificationItem->deviceInterface, &locationID);
+			if (KERN_SUCCESS != kr)
+			{
+				DEBUG_LOG("GetLocationID returned 0x%08x.\n", kr);
+				continue;
+			}
+			item->locationId = locationID;
+
+			kr = (*notificationItem->deviceInterface)->GetDeviceAddress(notificationItem->deviceInterface, &addr);
+			if (KERN_SUCCESS != kr)
+			{
+				DEBUG_LOG("GetDeviceAddress returned 0x%08x.\n", kr);
+				continue;
+			}
+			item->deviceAddress = addr;
+
+			kr = (*notificationItem->deviceInterface)->GetDeviceVendor(notificationItem->deviceInterface, &vendorId);
+			if (KERN_SUCCESS != kr)
+			{
+				DEBUG_LOG("GetDeviceVendor returned 0x%08x.\n", kr);
+				continue;
+			}
+			item->vendorId = vendorId;
+
+			kr = (*notificationItem->deviceInterface)->GetDeviceProduct(notificationItem->deviceInterface, &productId);
+			if (KERN_SUCCESS != kr)
+			{
+				DEBUG_LOG("GetDeviceProduct returned 0x%08x.\n", kr);
+				continue;
+			}
+			item->productId = productId;
+
+			// Extract path name as unique key
+			io_string_t pathName;
+			IORegistryEntryGetPath(usbDevice, kIOServicePlane, pathName);
+			deviceNameAsCFString = CFStringCreateWithCString(kCFAllocatorDefault, pathName, kCFStringEncodingASCII);
+			char cPathName[MAXPATHLEN];
+
+			if (deviceNameAsCFString)
+			{
+				Boolean result;
+
+				// Convert from a CFString to a C (NUL-terminated)
+				result = CFStringGetCString(
+					deviceNameAsCFString,
+					cPathName,
+					sizeof(cPathName),
+					kCFStringEncodingUTF8);
+
+				CFRelease(deviceNameAsCFString);
+			}
+
+			deviceMap.addItem(cPathName, item);
+			notificationItem->deviceItem = item;
+
+			if (notify)
+			{
+				DeviceAdded(item);
+			}
+
+			// Register for an interest notification of this device being removed. Use a reference to our
+			// private data as the refCon which will be passed to the notification callback.
+			kr = IOServiceAddInterestNotification(
+				gNotifyPort,					  // notifyPort
+				usbDevice,						  // service
+				kIOGeneralInterest,				  // interestType
+				DeviceRemovedOuter,				  // callback
+				notificationItem,				  // refCon
+				&(notificationItem->notification) // notification
+			);
+
+			if (KERN_SUCCESS != kr)
+			{
+				DEBUG_LOG("IOServiceAddInterestNotification returned 0x%08x.\n", kr);
+			}
+
+			// Done with this USB device; release the reference added by IOIteratorNext
+			kr = IOObjectRelease(usbDevice);
+		}
+	}
+
+private:
+	/**********************************
+	 * Local Variables
+	 **********************************/
+	std::thread poll_thread;
+
+	IONotificationPortRef gNotifyPort;
+	CFRunLoopRef gRunLoop;
+
+	CFMutableDictionaryRef matchingDict;
+
+	std::atomic<bool> isRunning = {false};
+};
+
+void InitializeDetection(Napi::Env &env, Napi::Object &target)
 {
-	if (isRunning)
-	{
-		return;
-	}
-
-	isRunning = true;
-
-	uv_mutex_init(&notify_mutex);
-	uv_async_init(uv_default_loop(), &async_handler, cbAsync);
-	uv_signal_init(uv_default_loop(), &term_signal);
-	uv_signal_init(uv_default_loop(), &int_signal);
-	uv_cond_init(&notifyDeviceHandled);
-
-	uv_queue_work(uv_default_loop(), &work_req, cbWork, cbAfter);
+	MacDetection::Initialize(env, target);
 }
 
-void Stop()
+static void DeviceAddedOuter(void *refCon, io_iterator_t iterator)
 {
-	if (!isRunning)
-	{
-		return;
-	}
-
-	isRunning = false;
-
-	uv_mutex_destroy(&notify_mutex);
-	uv_signal_stop(&int_signal);
-	uv_signal_stop(&term_signal);
-	uv_close((uv_handle_t *)&async_handler, NULL);
-	uv_cond_destroy(&notifyDeviceHandled);
-
-	if (gRunLoop)
-	{
-		CFRunLoopStop(gRunLoop);
-	}
+	MacDetection *parent = (MacDetection *)refCon;
+	parent->IterateFoundDevices(iterator, true);
 }
 
-void InitDetection()
+static void DeviceRemovedOuter(void *refCon, io_service_t service, natural_t messageType, void *messageArgument)
 {
 	kern_return_t kr;
+	NotificationDeviceItem *notifyItem = (NotificationDeviceItem *)refCon;
 
-	// Set up the matching criteria for the devices we're interested in. The matching criteria needs to follow
-	// the same rules as kernel drivers: mainly it needs to follow the USB Common Class Specification, pp. 6-7.
-	// See also Technical Q&A QA1076 "Tips on USB driver matching on Mac OS X"
-	// <http://developer.apple.com/qa/qa2001/qa1076.html>.
-	// One exception is that you can use the matching dictionary "as is", i.e. without adding any matching
-	// criteria to it and it will match every IOUSBDevice in the system. IOServiceAddMatchingNotification will
-	// consume this dictionary reference, so there is no need to release it later on.
-
-	// Interested in instances of class
-	// IOUSBDevice and its subclasses
-	matchingDict = IOServiceMatching(kIOUSBDeviceClassName);
-
-	if (matchingDict == NULL)
+	if (messageType == kIOMessageServiceIsTerminated)
 	{
-		DEBUG_LOG("IOServiceMatching returned NULL.\n");
+		if (notifyItem->deviceInterface)
+		{
+			kr = (*notifyItem->deviceInterface)->Release(notifyItem->deviceInterface);
+		}
+
+		kr = IOObjectRelease(notifyItem->notification);
+
+		notifyItem->parent->DeviceRemoved(notifyItem->deviceItem);
 	}
-
-	// Create a notification port and add its run loop event source to our run loop
-	// This is how async notifications get set up.
-
-	gNotifyPort = IONotificationPortCreate(kIOMasterPortDefault);
-
-	// Now set up a notification to be called when a device is first matched by I/O Kit.
-	kr = IOServiceAddMatchingNotification(
-		gNotifyPort,			   // notifyPort
-		kIOFirstMatchNotification, // notificationType
-		matchingDict,			   // matching
-		DeviceAdded,			   // callback
-		NULL,					   // refCon
-		&gAddedIter				   // notification
-	);
-
-	if (KERN_SUCCESS != kr)
-	{
-		DEBUG_LOG("IOServiceAddMatchingNotification returned 0x%08x.\n", kr);
-	}
-
-	// Iterate once to get already-present devices and arm the notification
-	DeviceAdded(NULL, gAddedIter);
-	initialDeviceImport = false;
-}
-
-static void WaitForDeviceHandled()
-{
-	uv_mutex_lock(&notify_mutex);
-	if (deviceHandled == false)
-	{
-		uv_cond_wait(&notifyDeviceHandled, &notify_mutex);
-	}
-	deviceHandled = false;
-	uv_mutex_unlock(&notify_mutex);
-}
-
-static void SignalDeviceHandled()
-{
-	uv_mutex_lock(&notify_mutex);
-	deviceHandled = true;
-	uv_cond_signal(&notifyDeviceHandled);
-	uv_mutex_unlock(&notify_mutex);
-}
-
-static void cbWork(uv_work_t *req)
-{
-	// We have this check in case we `Stop` before this thread starts,
-	// otherwise the process will hang
-	if (!isRunning)
-	{
-		return;
-	}
-
-	uv_signal_start(&int_signal, cbTerminate, SIGINT);
-	uv_signal_start(&term_signal, cbTerminate, SIGTERM);
-
-	runLoopSource = IONotificationPortGetRunLoopSource(gNotifyPort);
-
-	gRunLoop = CFRunLoopGetCurrent();
-	CFRunLoopAddSource(gRunLoop, runLoopSource, kCFRunLoopDefaultMode);
-
-	// Creating `gRunLoop` can take some cycles so we also need this second
-	// `isRunning` check here because it happens at a future time
-	if (isRunning)
-	{
-		// Start the run loop. Now we'll receive notifications.
-		CFRunLoopRun();
-	}
-
-	// The `CFRunLoopRun` is a blocking call so we also need this second
-	// `isRunning` check here because it happens at a future time
-	if (isRunning)
-	{
-		// We should never get here while running
-		DEBUG_LOG("Unexpectedly back from CFRunLoopRun()!\n");
-	}
-}
-
-static void cbAfter(uv_work_t *req, int status)
-{
-	Stop();
-}
-
-static void cbAsync(uv_async_t *handle)
-{
-	if (!isRunning)
-	{
-		return;
-	}
-
-	if (isAdded)
-	{
-		NotifyAdded(currentItem);
-	}
-	else
-	{
-		NotifyRemoved(currentItem);
-	}
-
-	// Delete Item in case of removal
-	if (isAdded == false)
-	{
-		delete currentItem;
-	}
-
-	SignalDeviceHandled();
-}
-
-static void cbTerminate(uv_signal_t *handle, int signum)
-{
-	Stop();
 }

--- a/src/detection_mac.cpp
+++ b/src/detection_mac.cpp
@@ -419,13 +419,6 @@ void InitDetection()
 	initialDeviceImport = false;
 }
 
-void EIO_Find(uv_work_t *req)
-{
-	ListBaton *data = static_cast<ListBaton *>(req->data);
-
-	CreateFilteredList(&data->results, data->vid, data->pid);
-}
-
 static void WaitForDeviceHandled()
 {
 	uv_mutex_lock(&notify_mutex);

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -30,7 +30,6 @@ typedef std::basic_string<TCHAR> tstring;
 
 #define LIBRARY_NAME ("setupapi.dll")
 
-
 #define DllImport __declspec(dllimport)
 
 #define MAX_THREAD_WINDOW_NAME 64
@@ -38,8 +37,6 @@ typedef std::basic_string<TCHAR> tstring;
 /**********************************
  * Local typedefs
  **********************************/
-
-
 
 /**********************************
  * Local Variables
@@ -55,8 +52,7 @@ GUID GUID_DEVINTERFACE_USB_DEVICE = {
 	0x4F,
 	0xB9,
 	0x51,
-	0xED
-};
+	0xED};
 
 DWORD threadId;
 HANDLE threadHandle;
@@ -67,26 +63,23 @@ HANDLE deviceChangedSentEvent;
 uv_signal_t term_signal;
 uv_signal_t int_signal;
 
-ListResultItem_t* currentDevice;
+ListResultItem_t *currentDevice;
 bool isAdded;
 bool isRunning = false;
 
 HINSTANCE hinstLib;
 
-
-typedef BOOL (WINAPI *_SetupDiEnumDeviceInfo) (HDEVINFO DeviceInfoSet, DWORD MemberIndex, PSP_DEVINFO_DATA DeviceInfoData);
-typedef HDEVINFO (WINAPI *_SetupDiGetClassDevs) (const GUID *ClassGuid, PCTSTR Enumerator, HWND hwndParent, DWORD Flags);
-typedef BOOL (WINAPI *_SetupDiDestroyDeviceInfoList) (HDEVINFO DeviceInfoSet);
-typedef BOOL (WINAPI *_SetupDiGetDeviceInstanceId) (HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, PTSTR DeviceInstanceId, DWORD DeviceInstanceIdSize, PDWORD RequiredSize);
-typedef BOOL (WINAPI *_SetupDiGetDeviceRegistryProperty) (HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, DWORD Property, PDWORD PropertyRegDataType, PBYTE PropertyBuffer, DWORD PropertyBufferSize, PDWORD RequiredSize);
-
+typedef BOOL(WINAPI *_SetupDiEnumDeviceInfo)(HDEVINFO DeviceInfoSet, DWORD MemberIndex, PSP_DEVINFO_DATA DeviceInfoData);
+typedef HDEVINFO(WINAPI *_SetupDiGetClassDevs)(const GUID *ClassGuid, PCTSTR Enumerator, HWND hwndParent, DWORD Flags);
+typedef BOOL(WINAPI *_SetupDiDestroyDeviceInfoList)(HDEVINFO DeviceInfoSet);
+typedef BOOL(WINAPI *_SetupDiGetDeviceInstanceId)(HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, PTSTR DeviceInstanceId, DWORD DeviceInstanceIdSize, PDWORD RequiredSize);
+typedef BOOL(WINAPI *_SetupDiGetDeviceRegistryProperty)(HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, DWORD Property, PDWORD PropertyRegDataType, PBYTE PropertyBuffer, DWORD PropertyBufferSize, PDWORD RequiredSize);
 
 _SetupDiEnumDeviceInfo DllSetupDiEnumDeviceInfo;
 _SetupDiGetClassDevs DllSetupDiGetClassDevs;
 _SetupDiDestroyDeviceInfoList DllSetupDiDestroyDeviceInfoList;
 _SetupDiGetDeviceInstanceId DllSetupDiGetDeviceInstanceId;
 _SetupDiGetDeviceRegistryProperty DllSetupDiGetDeviceRegistryProperty;
-
 
 /**********************************
  * Local Helper Functions protoypes
@@ -97,21 +90,22 @@ DWORD WINAPI ListenerThread(LPVOID lpParam);
 
 void BuildInitialDeviceList();
 
-void cbWork(uv_work_t* req);
-void cbAfter(uv_work_t* req);
+void cbWork(uv_work_t *req);
+void cbAfter(uv_work_t *req);
 void cbTerminate(uv_signal_t *handle, int signum);
 
-void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* buf, DWORD buffSize, ListResultItem_t* resultItem);
-bool CheckValidity(ListResultItem_t* item);
-
+void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA *pspDevInfoData, TCHAR *buf, DWORD buffSize, ListResultItem_t *resultItem);
+bool CheckValidity(ListResultItem_t *item);
 
 /**********************************
  * Public Functions
  **********************************/
-void cbWork(uv_work_t* req) {
+void cbWork(uv_work_t *req)
+{
 	// We have this check in case we `Stop` before this thread starts,
 	// otherwise the process will hang
-	if(!isRunning) {
+	if (!isRunning)
+	{
 		return;
 	}
 
@@ -121,21 +115,25 @@ void cbWork(uv_work_t* req) {
 	WaitForSingleObject(deviceChangedRegisteredEvent, INFINITE);
 }
 
-
-void cbAfter(uv_work_t* req) {
-	if(!isRunning) {
+void cbAfter(uv_work_t *req)
+{
+	if (!isRunning)
+	{
 		return;
 	}
 
-	if(isAdded) {
+	if (isAdded)
+	{
 		NotifyAdded(currentDevice);
 	}
-	else {
+	else
+	{
 		NotifyRemoved(currentDevice);
 	}
 
 	// Delete Item in case of removal
-	if(!isAdded) {
+	if (!isAdded)
+	{
 		delete currentDevice;
 	}
 
@@ -146,47 +144,52 @@ void cbAfter(uv_work_t* req) {
 	uv_queue_work(uv_default_loop(), req, cbWork, (uv_after_work_cb)cbAfter);
 }
 
-void cbTerminate(uv_signal_t *handle, int signum) {
+void cbTerminate(uv_signal_t *handle, int signum)
+{
 	Stop();
 }
 
-void LoadFunctions() {
+void LoadFunctions()
+{
 
 	bool success;
 
 	hinstLib = LoadLibrary(LIBRARY_NAME);
 
-	if (hinstLib != NULL) {
-		DllSetupDiEnumDeviceInfo = (_SetupDiEnumDeviceInfo) GetProcAddress(hinstLib, "SetupDiEnumDeviceInfo");
+	if (hinstLib != NULL)
+	{
+		DllSetupDiEnumDeviceInfo = (_SetupDiEnumDeviceInfo)GetProcAddress(hinstLib, "SetupDiEnumDeviceInfo");
 
-		DllSetupDiGetClassDevs = (_SetupDiGetClassDevs) GetProcAddress(hinstLib, "SetupDiGetClassDevsA");
+		DllSetupDiGetClassDevs = (_SetupDiGetClassDevs)GetProcAddress(hinstLib, "SetupDiGetClassDevsA");
 
-		DllSetupDiDestroyDeviceInfoList = (_SetupDiDestroyDeviceInfoList) GetProcAddress(hinstLib, "SetupDiDestroyDeviceInfoList");
+		DllSetupDiDestroyDeviceInfoList = (_SetupDiDestroyDeviceInfoList)GetProcAddress(hinstLib, "SetupDiDestroyDeviceInfoList");
 
-		DllSetupDiGetDeviceInstanceId = (_SetupDiGetDeviceInstanceId) GetProcAddress(hinstLib, "SetupDiGetDeviceInstanceIdA");
+		DllSetupDiGetDeviceInstanceId = (_SetupDiGetDeviceInstanceId)GetProcAddress(hinstLib, "SetupDiGetDeviceInstanceIdA");
 
-		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty) GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA");
+		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty)GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA");
 
-		success = (
-			DllSetupDiEnumDeviceInfo != NULL &&
-			DllSetupDiGetClassDevs != NULL &&
-			DllSetupDiDestroyDeviceInfoList != NULL &&
-			DllSetupDiGetDeviceInstanceId != NULL &&
-			DllSetupDiGetDeviceRegistryProperty != NULL
-		);
+		success = (DllSetupDiEnumDeviceInfo != NULL &&
+				   DllSetupDiGetClassDevs != NULL &&
+				   DllSetupDiDestroyDeviceInfoList != NULL &&
+				   DllSetupDiGetDeviceInstanceId != NULL &&
+				   DllSetupDiGetDeviceRegistryProperty != NULL);
 	}
-	else {
+	else
+	{
 		success = false;
 	}
 
-	if(!success) {
+	if (!success)
+	{
 		printf("Could not load library functions from dll -> abort (Check if %s is available)\r\n", LIBRARY_NAME);
 		exit(1);
 	}
 }
 
-void Start() {
-	if(isRunning) {
+void Start()
+{
+	if (isRunning)
+	{
 		return;
 	}
 
@@ -194,23 +197,24 @@ void Start() {
 
 	// Start listening for the Windows API events
 	threadHandle = CreateThread(
-		NULL, // default security attributes
-		0, // use default stack size
+		NULL,			// default security attributes
+		0,				// use default stack size
 		ListenerThread, // thread function name
-		NULL, // argument to thread function
-		0, // use default creation flags
-		&threadId
-	);
+		NULL,			// argument to thread function
+		0,				// use default creation flags
+		&threadId);
 
 	uv_signal_init(uv_default_loop(), &term_signal);
 	uv_signal_init(uv_default_loop(), &int_signal);
 
-	uv_work_t* req = new uv_work_t();
+	uv_work_t *req = new uv_work_t();
 	uv_queue_work(uv_default_loop(), req, cbWork, (uv_after_work_cb)cbAfter);
 }
 
-void Stop() {
-	if(!isRunning) {
+void Stop()
+{
+	if (!isRunning)
+	{
 		return;
 	}
 
@@ -222,64 +226,68 @@ void Stop() {
 	SetEvent(deviceChangedRegisteredEvent);
 }
 
-void InitDetection() {
+void InitDetection()
+{
 	LoadFunctions();
 
 	deviceChangedRegisteredEvent = CreateEvent(
 		NULL,
 		false, // auto-reset event
 		false, // non-signalled state
-		""
-	);
+		"");
 	deviceChangedSentEvent = CreateEvent(
 		NULL,
 		false, // auto-reset event
-		true, // non-signalled state
-		""
-	);
+		true,  // non-signalled state
+		"");
 
 	BuildInitialDeviceList();
 }
 
+void EIO_Find(uv_work_t *req)
+{
 
-void EIO_Find(uv_work_t* req) {
-
-	ListBaton* data = static_cast<ListBaton*>(req->data);
+	ListBaton *data = static_cast<ListBaton *>(req->data);
 
 	CreateFilteredList(&data->results, data->vid, data->pid);
 }
 
-
 /**********************************
  * Local Functions
  **********************************/
-void ToUpper(char * buf) {
-	char* c = buf;
-	while (*c != '\0') {
+void ToUpper(char *buf)
+{
+	char *c = buf;
+	while (*c != '\0')
+	{
 		*c = toupper((unsigned char)*c);
 		c++;
 	}
 }
 
-void NormalizeSlashes(char* buf) {
-	char* c = buf;
-	while (*c != '\0') {
-		if(*c == '/')
+void NormalizeSlashes(char *buf)
+{
+	char *c = buf;
+	while (*c != '\0')
+	{
+		if (*c == '/')
 			*c = '\\';
 		c++;
 	}
 }
 
-void extractVidPid(char * buf, ListResultItem_t * item) {
-	if(buf == NULL) {
+void extractVidPid(char *buf, ListResultItem_t *item)
+{
+	if (buf == NULL)
+	{
 		return;
 	}
 
 	ToUpper(buf);
 
-	char* string;
-	char* temp;
-	char* pidStr, *vidStr;
+	char *string;
+	char *temp;
+	char *pidStr, *vidStr;
 	int vid = 0;
 	int pid = 0;
 
@@ -289,16 +297,18 @@ void extractVidPid(char * buf, ListResultItem_t * item) {
 	vidStr = strstr(string, VID_TAG);
 	pidStr = strstr(string, PID_TAG);
 
-	if(vidStr != NULL) {
-		temp = (char*) (vidStr + strlen(VID_TAG));
+	if (vidStr != NULL)
+	{
+		temp = (char *)(vidStr + strlen(VID_TAG));
 		temp[4] = '\0';
-		vid = strtol (temp, NULL, 16);
+		vid = strtol(temp, NULL, 16);
 	}
 
-	if(pidStr != NULL) {
-		temp = (char*) (pidStr + strlen(PID_TAG));
+	if (pidStr != NULL)
+	{
+		temp = (char *)(pidStr + strlen(PID_TAG));
 		temp[4] = '\0';
-		pid = strtol (temp, NULL, 16);
+		pid = strtol(temp, NULL, 16);
 	}
 	item->vendorId = vid;
 	item->productId = pid;
@@ -306,14 +316,17 @@ void extractVidPid(char * buf, ListResultItem_t * item) {
 	delete string;
 }
 
-
-LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-	if (msg == WM_DEVICECHANGE) {
-		if ( DBT_DEVICEARRIVAL == wParam || DBT_DEVICEREMOVECOMPLETE == wParam ) {
+LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	if (msg == WM_DEVICECHANGE)
+	{
+		if (DBT_DEVICEARRIVAL == wParam || DBT_DEVICEREMOVECOMPLETE == wParam)
+		{
 			PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
 			PDEV_BROADCAST_DEVICEINTERFACE pDevInf;
 
-			if(pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE) {
+			if (pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+			{
 				pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
 				UpdateDevice(pDevInf, wParam, (DBT_DEVICEARRIVAL == wParam) ? DeviceState_Connect : DeviceState_Disconnect);
 			}
@@ -323,8 +336,8 @@ LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 	return 1;
 }
 
-
-DWORD WINAPI ListenerThread( LPVOID lpParam ) {
+DWORD WINAPI ListenerThread(LPVOID lpParam)
+{
 	char className[MAX_THREAD_WINDOW_NAME];
 	_snprintf_s(className, MAX_THREAD_WINDOW_NAME, "ListnerThreadUsbDetection_%d", GetCurrentThreadId());
 
@@ -333,15 +346,16 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 	wincl.lpszClassName = className;
 	wincl.lpfnWndProc = DetectCallback;
 
-	if (!RegisterClassA(&wincl)) {
+	if (!RegisterClassA(&wincl))
+	{
 		DWORD le = GetLastError();
 		printf("RegisterClassA() failed [Error: %x]\r\n", le);
 		return 1;
 	}
 
-
 	HWND hwnd = CreateWindowExA(WS_EX_TOPMOST, className, className, 0, 0, 0, 0, 0, NULL, 0, 0, 0);
-	if (!hwnd) {
+	if (!hwnd)
+	{
 		DWORD le = GetLastError();
 		printf("CreateWindowExA() failed [Error: %x]\r\n", le);
 		return 1;
@@ -353,16 +367,19 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 	notifyFilter.dbcc_classguid = GUID_DEVINTERFACE_USB_DEVICE;
 
 	HDEVNOTIFY hDevNotify = RegisterDeviceNotificationA(hwnd, &notifyFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
-	if (!hDevNotify) {
+	if (!hDevNotify)
+	{
 		DWORD le = GetLastError();
 		printf("RegisterDeviceNotificationA() failed [Error: %x]\r\n", le);
 		return 1;
 	}
 
 	MSG msg;
-	while(TRUE) {
+	while (TRUE)
+	{
 		BOOL bRet = GetMessage(&msg, hwnd, 0, 0);
-		if ((bRet == 0) || (bRet == -1)) {
+		if ((bRet == 0) || (bRet == -1))
+		{
 			break;
 		}
 
@@ -373,48 +390,52 @@ DWORD WINAPI ListenerThread( LPVOID lpParam ) {
 	return 0;
 }
 
-
-void BuildInitialDeviceList() {
+void BuildInitialDeviceList()
+{
 	DWORD dwFlag = (DIGCF_ALLCLASSES | DIGCF_PRESENT);
 	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, "USB", NULL, dwFlag);
 
-	if(INVALID_HANDLE_VALUE == hDevInfo) {
+	if (INVALID_HANDLE_VALUE == hDevInfo)
+	{
 		return;
 	}
 
-	SP_DEVINFO_DATA* pspDevInfoData = (SP_DEVINFO_DATA*) HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
-	if (pspDevInfoData) {
+	SP_DEVINFO_DATA *pspDevInfoData = (SP_DEVINFO_DATA *)HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
+	if (pspDevInfoData)
+	{
 		pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
-		for(int i=0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++) {
-			DWORD nSize=0 ;
+		for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++)
+		{
+			DWORD nSize = 0;
 			TCHAR buf[MAX_PATH];
 
-			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize)) {
+			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize))
+			{
 				break;
 			}
 			NormalizeSlashes(buf);
 
-			DeviceItem_t* item = new DeviceItem_t();
-			item->deviceState = DeviceState_Connect;
+			ListResultItem_t *item = new ListResultItem_t();
 
 			DWORD DataT;
 			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
 			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
 
 			AddItemToList(buf, item);
-			ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &item->deviceParams);
+			ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, item);
 		}
 
 		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
 	}
 
-	if(hDevInfo) {
+	if (hDevInfo)
+	{
 		DllSetupDiDestroyDeviceInfoList(hDevInfo);
 	}
 }
 
-
-void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR* buf, DWORD buffSize, ListResultItem_t* resultItem) {
+void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA *pspDevInfoData, TCHAR *buf, DWORD buffSize, ListResultItem_t *resultItem)
+{
 
 	DWORD DataT;
 	DWORD nSize;
@@ -424,17 +445,20 @@ void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR
 	resultItem->deviceAddress = dummy++;
 
 	// device found
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, buffSize, &nSize)) {
-		resultItem->deviceName = Utf8Encode(buf);
-	}
-	else if ( DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize))
+	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, buffSize, &nSize))
 	{
 		resultItem->deviceName = Utf8Encode(buf);
 	}
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, buffSize, &nSize)) {
+	else if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize))
+	{
+		resultItem->deviceName = Utf8Encode(buf);
+	}
+	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, buffSize, &nSize))
+	{
 		resultItem->manufacturer = Utf8Encode(buf);
 	}
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, buffSize, &nSize)) {
+	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, buffSize, &nSize))
+	{
 		// Use this to extract VID / PID
 		extractVidPid(buf, resultItem);
 	}
@@ -451,14 +475,18 @@ void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR
 	//  - [Device IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-ids) -> [Hardware IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/hardware-ids) -> [Device identifier formats](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-identifier-formats) -> [Identifiers for USB devices](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-usb-devices)
 	//     - [Standard USB Identifiers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/standard-usb-identifiers)
 	//     - [Special USB Identifiers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/special-usb-identifiers)
-	//  - [Instance specific ID](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/instance-ids) 
+	//  - [Instance specific ID](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/instance-ids)
 	DWORD dwCapabilities = 0x0;
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_CAPABILITIES, &DataT, (PBYTE)&dwCapabilities, sizeof(dwCapabilities), &nSize)) {
-		if ((dwCapabilities & CM_DEVCAP_UNIQUEID) == CM_DEVCAP_UNIQUEID) {
-			if (DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, buffSize, &nSize)) {
+	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_CAPABILITIES, &DataT, (PBYTE)&dwCapabilities, sizeof(dwCapabilities), &nSize))
+	{
+		if ((dwCapabilities & CM_DEVCAP_UNIQUEID) == CM_DEVCAP_UNIQUEID)
+		{
+			if (DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, buffSize, &nSize))
+			{
 				string deviceInstanceId = buf;
 				size_t serialNumberIndex = deviceInstanceId.find_last_of("\\");
-				if (serialNumberIndex != string::npos) {
+				if (serialNumberIndex != string::npos)
+				{
 					resultItem->serialNumber = deviceInstanceId.substr(serialNumberIndex + 1);
 				}
 			}
@@ -466,72 +494,84 @@ void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA* pspDevInfoData, TCHAR
 	}
 }
 
-
-void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state) {
+void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state)
+{
 	// dbcc_name:
 	// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
 	// convert to
 	// USB\Vid_04e8&Pid_503b\0002F9A9828E0F06
-	tstring szDevId = pDevInf->dbcc_name+4;
+	tstring szDevId = pDevInf->dbcc_name + 4;
 	auto idx = szDevId.rfind(_T('#'));
 
-	if (idx != tstring::npos) szDevId.resize(idx);
+	if (idx != tstring::npos)
+		szDevId.resize(idx);
 	std::replace(begin(szDevId), end(szDevId), _T('#'), _T('\\'));
-	auto to_upper = [] (TCHAR ch) { return std::use_facet<std::ctype<TCHAR>>(std::locale()).toupper(ch); };
+	auto to_upper = [](TCHAR ch) { return std::use_facet<std::ctype<TCHAR>>(std::locale()).toupper(ch); };
 	transform(begin(szDevId), end(szDevId), begin(szDevId), to_upper);
 
 	tstring szClass;
 	idx = szDevId.find(_T('\\'));
-	if (idx != tstring::npos) szClass = szDevId.substr(0, idx);
+	if (idx != tstring::npos)
+		szClass = szDevId.substr(0, idx);
 	// if we are adding device, we only need present devices
 	// otherwise, we need all devices
 	DWORD dwFlag = DBT_DEVICEARRIVAL != wParam ? DIGCF_ALLCLASSES : (DIGCF_ALLCLASSES | DIGCF_PRESENT);
 	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, szClass.c_str(), NULL, dwFlag);
-	if(INVALID_HANDLE_VALUE == hDevInfo) {
+	if (INVALID_HANDLE_VALUE == hDevInfo)
+	{
 		return;
 	}
 
-	SP_DEVINFO_DATA* pspDevInfoData = (SP_DEVINFO_DATA*) HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
-	if (pspDevInfoData) {
+	SP_DEVINFO_DATA *pspDevInfoData = (SP_DEVINFO_DATA *)HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
+	if (pspDevInfoData)
+	{
 		pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
-		for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++) {
+		for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++)
+		{
 			DWORD nSize = 0;
 			TCHAR buf[MAX_PATH];
 
-			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize)) {
+			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize))
+			{
 				break;
 			}
 			NormalizeSlashes(buf);
 
-			if (szDevId == buf) {
+			if (szDevId == buf)
+			{
 				WaitForSingleObject(deviceChangedSentEvent, INFINITE);
 
 				DWORD DataT;
 				DWORD nSize;
-				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE) buf, MAX_PATH, &nSize);
+				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
 				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
 
-				if (state == DeviceState_Connect) {
-					DeviceItem_t *device = new DeviceItem_t();
+				if (state == DeviceState_Connect)
+				{
+					ListResultItem_t *device = new ListResultItem_t();
 
 					AddItemToList(buf, device);
-					ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, &device->deviceParams);
+					ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, device);
 
 					currentDevice = &device->deviceParams;
 					isAdded = true;
-				} else {
+				}
+				else
+				{
 
 					ListResultItem_t *item = NULL;
-					if (IsItemAlreadyStored(buf)) {
-						DeviceItem_t *deviceItem = GetItemFromList(buf);
-						if (deviceItem) {
-							item = CopyElement(&deviceItem->deviceParams);
+					if (IsItemAlreadyStored(buf))
+					{
+						ListResultItem_t *deviceItem = PopItemFromList(buf);
+						if (deviceItem)
+						{
+							item = CopyElement(deviceItem);
+							delete deviceItem;
 						}
-						RemoveItemFromList(deviceItem);
-						delete deviceItem;
 					}
 
-					if (item == NULL) {
+					if (item == NULL)
+					{
 						item = new ListResultItem_t();
 						ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, item);
 					}
@@ -546,7 +586,8 @@ void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceS
 		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
 	}
 
-	if(hDevInfo) {
+	if (hDevInfo)
+	{
 		DllSetupDiDestroyDeviceInfoList(hDevInfo);
 	}
 
@@ -555,19 +596,20 @@ void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceS
 
 std::string Utf8Encode(const std::string &str)
 {
-    if (str.empty()) {
-        return std::string();
-    }
+	if (str.empty())
+	{
+		return std::string();
+	}
 
-    //System default code page to wide character
-    int wstr_size = MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, NULL, 0);
-    std::wstring wstr_tmp(wstr_size, 0);
-    MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, &wstr_tmp[0], wstr_size);
+	//System default code page to wide character
+	int wstr_size = MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, NULL, 0);
+	std::wstring wstr_tmp(wstr_size, 0);
+	MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, &wstr_tmp[0], wstr_size);
 
-    //Wide character to Utf8
-    int str_size = WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), NULL, 0, NULL, NULL);
-    std::string str_utf8(str_size, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), &str_utf8[0], str_size, NULL, NULL);
+	//Wide character to Utf8
+	int str_size = WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), NULL, 0, NULL, NULL);
+	std::string str_utf8(str_size, 0);
+	WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), &str_utf8[0], str_size, NULL, NULL);
 
-    return str_utf8;
+	return str_utf8;
 }

--- a/src/detection_win.cpp
+++ b/src/detection_win.cpp
@@ -1,5 +1,3 @@
-#include <uv.h>
-#include <dbt.h>
 #include <iostream>
 #include <iomanip>
 #include <string>
@@ -14,6 +12,7 @@
 #include <tchar.h>
 #include <strsafe.h>
 #include <Setupapi.h>
+#include <dbt.h>
 
 #include "detection.h"
 #include "deviceList.h"
@@ -54,19 +53,6 @@ GUID GUID_DEVINTERFACE_USB_DEVICE = {
 	0x51,
 	0xED};
 
-DWORD threadId;
-HANDLE threadHandle;
-
-HANDLE deviceChangedRegisteredEvent;
-HANDLE deviceChangedSentEvent;
-
-uv_signal_t term_signal;
-uv_signal_t int_signal;
-
-ListResultItem_t *currentDevice;
-bool isAdded;
-bool isRunning = false;
-
 HINSTANCE hinstLib;
 
 typedef BOOL(WINAPI *_SetupDiEnumDeviceInfo)(HDEVINFO DeviceInfoSet, DWORD MemberIndex, PSP_DEVINFO_DATA DeviceInfoData);
@@ -82,187 +68,27 @@ _SetupDiGetDeviceInstanceId DllSetupDiGetDeviceInstanceId;
 _SetupDiGetDeviceRegistryProperty DllSetupDiGetDeviceRegistryProperty;
 
 /**********************************
- * Local Helper Functions protoypes
+ * Local Helper Functions
  **********************************/
-void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state);
-std::string Utf8Encode(const std::string &str);
-DWORD WINAPI ListenerThread(LPVOID lpParam);
 
-void BuildInitialDeviceList();
-
-void cbWork(uv_work_t *req);
-void cbAfter(uv_work_t *req);
-void cbTerminate(uv_signal_t *handle, int signum);
-
-void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA *pspDevInfoData, TCHAR *buf, DWORD buffSize, ListResultItem_t *resultItem);
-bool CheckValidity(ListResultItem_t *item);
-
-/**********************************
- * Public Functions
- **********************************/
-void cbWork(uv_work_t *req)
+std::string Utf8Encode(const std::string &str)
 {
-	// We have this check in case we `Stop` before this thread starts,
-	// otherwise the process will hang
-	if (!isRunning)
+	if (str.empty())
 	{
-		return;
+		return std::string();
 	}
 
-	uv_signal_start(&int_signal, cbTerminate, SIGINT);
-	uv_signal_start(&term_signal, cbTerminate, SIGTERM);
+	//System default code page to wide character
+	int wstr_size = MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, NULL, 0);
+	std::wstring wstr_tmp(wstr_size, 0);
+	MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, &wstr_tmp[0], wstr_size);
 
-	WaitForSingleObject(deviceChangedRegisteredEvent, INFINITE);
-}
+	//Wide character to Utf8
+	int str_size = WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), NULL, 0, NULL, NULL);
+	std::string str_utf8(str_size, 0);
+	WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), &str_utf8[0], str_size, NULL, NULL);
 
-void cbAfter(uv_work_t *req)
-{
-	if (!isRunning)
-	{
-		return;
-	}
-
-	if (isAdded)
-	{
-		NotifyAdded(currentDevice);
-	}
-	else
-	{
-		NotifyRemoved(currentDevice);
-	}
-
-	// Delete Item in case of removal
-	if (!isAdded)
-	{
-		delete currentDevice;
-	}
-
-	SetEvent(deviceChangedSentEvent);
-
-	currentDevice = NULL;
-
-	uv_queue_work(uv_default_loop(), req, cbWork, (uv_after_work_cb)cbAfter);
-}
-
-void cbTerminate(uv_signal_t *handle, int signum)
-{
-	Stop();
-}
-
-void LoadFunctions()
-{
-
-	bool success;
-
-	hinstLib = LoadLibrary(LIBRARY_NAME);
-
-	if (hinstLib != NULL)
-	{
-		DllSetupDiEnumDeviceInfo = (_SetupDiEnumDeviceInfo)GetProcAddress(hinstLib, "SetupDiEnumDeviceInfo");
-
-		DllSetupDiGetClassDevs = (_SetupDiGetClassDevs)GetProcAddress(hinstLib, "SetupDiGetClassDevsA");
-
-		DllSetupDiDestroyDeviceInfoList = (_SetupDiDestroyDeviceInfoList)GetProcAddress(hinstLib, "SetupDiDestroyDeviceInfoList");
-
-		DllSetupDiGetDeviceInstanceId = (_SetupDiGetDeviceInstanceId)GetProcAddress(hinstLib, "SetupDiGetDeviceInstanceIdA");
-
-		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty)GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA");
-
-		success = (DllSetupDiEnumDeviceInfo != NULL &&
-				   DllSetupDiGetClassDevs != NULL &&
-				   DllSetupDiDestroyDeviceInfoList != NULL &&
-				   DllSetupDiGetDeviceInstanceId != NULL &&
-				   DllSetupDiGetDeviceRegistryProperty != NULL);
-	}
-	else
-	{
-		success = false;
-	}
-
-	if (!success)
-	{
-		printf("Could not load library functions from dll -> abort (Check if %s is available)\r\n", LIBRARY_NAME);
-		exit(1);
-	}
-}
-
-void Start()
-{
-	if (isRunning)
-	{
-		return;
-	}
-
-	isRunning = true;
-
-	// Start listening for the Windows API events
-	threadHandle = CreateThread(
-		NULL,			// default security attributes
-		0,				// use default stack size
-		ListenerThread, // thread function name
-		NULL,			// argument to thread function
-		0,				// use default creation flags
-		&threadId);
-
-	uv_signal_init(uv_default_loop(), &term_signal);
-	uv_signal_init(uv_default_loop(), &int_signal);
-
-	uv_work_t *req = new uv_work_t();
-	uv_queue_work(uv_default_loop(), req, cbWork, (uv_after_work_cb)cbAfter);
-}
-
-void Stop()
-{
-	if (!isRunning)
-	{
-		return;
-	}
-
-	isRunning = false;
-
-	uv_signal_stop(&int_signal);
-	uv_signal_stop(&term_signal);
-
-	SetEvent(deviceChangedRegisteredEvent);
-}
-
-void InitDetection()
-{
-	LoadFunctions();
-
-	deviceChangedRegisteredEvent = CreateEvent(
-		NULL,
-		false, // auto-reset event
-		false, // non-signalled state
-		"");
-	deviceChangedSentEvent = CreateEvent(
-		NULL,
-		false, // auto-reset event
-		true,  // non-signalled state
-		"");
-
-	BuildInitialDeviceList();
-}
-
-void EIO_Find(uv_work_t *req)
-{
-
-	ListBaton *data = static_cast<ListBaton *>(req->data);
-
-	CreateFilteredList(&data->results, data->vid, data->pid);
-}
-
-/**********************************
- * Local Functions
- **********************************/
-void ToUpper(char *buf)
-{
-	char *c = buf;
-	while (*c != '\0')
-	{
-		*c = toupper((unsigned char)*c);
-		c++;
-	}
+	return str_utf8;
 }
 
 void NormalizeSlashes(char *buf)
@@ -272,6 +98,16 @@ void NormalizeSlashes(char *buf)
 	{
 		if (*c == '/')
 			*c = '\\';
+		c++;
+	}
+}
+
+void ToUpper(char *buf)
+{
+	char *c = buf;
+	while (*c != '\0')
+	{
+		*c = toupper((unsigned char)*c);
 		c++;
 	}
 }
@@ -316,300 +152,443 @@ void extractVidPid(char *buf, ListResultItem_t *item)
 	delete string;
 }
 
+
+bool LoadFunctions()
+{
+
+	bool success;
+
+	hinstLib = LoadLibrary(LIBRARY_NAME);
+
+	if (hinstLib != NULL)
+	{
+		DllSetupDiEnumDeviceInfo = (_SetupDiEnumDeviceInfo)GetProcAddress(hinstLib, "SetupDiEnumDeviceInfo");
+
+		DllSetupDiGetClassDevs = (_SetupDiGetClassDevs)GetProcAddress(hinstLib, "SetupDiGetClassDevsA");
+
+		DllSetupDiDestroyDeviceInfoList = (_SetupDiDestroyDeviceInfoList)GetProcAddress(hinstLib, "SetupDiDestroyDeviceInfoList");
+
+		DllSetupDiGetDeviceInstanceId = (_SetupDiGetDeviceInstanceId)GetProcAddress(hinstLib, "SetupDiGetDeviceInstanceIdA");
+
+		DllSetupDiGetDeviceRegistryProperty = (_SetupDiGetDeviceRegistryProperty)GetProcAddress(hinstLib, "SetupDiGetDeviceRegistryPropertyA");
+
+		success = (DllSetupDiEnumDeviceInfo != NULL &&
+				   DllSetupDiGetClassDevs != NULL &&
+				   DllSetupDiDestroyDeviceInfoList != NULL &&
+				   DllSetupDiGetDeviceInstanceId != NULL &&
+				   DllSetupDiGetDeviceRegistryProperty != NULL);
+	}
+	else
+	{
+		success = false;
+	}
+
+	return success;
+}
+
+LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+/**********************************
+ * Public Functions
+ **********************************/
+
+class WindowsDetection : public Detection, public Napi::ObjectWrap<WindowsDetection>
+{
+public:
+	WindowsDetection(const Napi::CallbackInfo &info)
+		: Napi::ObjectWrap<WindowsDetection>(info)
+	{
+	}
+
+	static void Initialize(Napi::Env &env, Napi::Object &target)
+	{
+		Napi::Function ctor = DefineClass(env, "Detection",
+										  {
+											  InstanceMethod("isMonitoring", &Detection::IsMonitoring),
+											  InstanceMethod("startMonitoring", &Detection::StartMonitoring),
+											  InstanceMethod("stopMonitoring", &Detection::StopMonitoring),
+											  InstanceMethod("findDevices", &Detection::FindDevices),
+										  });
+
+		target.Set("Detection", ctor);
+		// constructor = Napi::Persistent(ctor);
+		// constructor.SuppressDestruct();
+	}
+
+	bool IsRunning()
+	{
+		return isRunning;
+	}
+	bool Start(const Napi::Env &env, const Napi::Function &callback)
+	{
+		if (isRunning)
+		{
+			return true;
+		}
+
+		isRunning = true;
+		
+		if (!LoadFunctions())
+		{
+			printf("Could not load library functions from dll -> abort (Check if %s is available)\r\n", LIBRARY_NAME);
+			return false;
+		}
+
+		// Do initial scan
+		BuildInitialDeviceList();
+
+		notify_func = Napi::ThreadSafeFunction::New(
+			env,
+			callback,		 // JavaScript function called asynchronously
+			"Resource Name", // Name
+			0,				 // Unlimited queue
+			1,				 // Only one thread will use this initially
+			[=](Napi::Env) { // Finalizer used to clean threads up
+				// Wait for end of the thread, if it wasnt the one to close up
+				if (poll_thread.joinable())
+				{
+					poll_thread.join();
+				}
+			});
+
+		poll_thread = std::thread([=]() {
+			// We have this check in case we `Stop` before this thread starts,
+			// otherwise the process will hang
+			if (!isRunning)
+			{
+				return;
+			}
+
+			char className[MAX_THREAD_WINDOW_NAME];
+			_snprintf_s(className, MAX_THREAD_WINDOW_NAME, "ListnerThreadUsbDetection_%d", GetCurrentThreadId());
+
+			WNDCLASSA wincl = {0};
+			wincl.hInstance = GetModuleHandle(0);
+			wincl.lpszClassName = className;
+			wincl.lpfnWndProc = DetectCallback;
+			
+			DEV_BROADCAST_DEVICEINTERFACE_A notifyFilter = {0};
+			notifyFilter.dbcc_size = sizeof(notifyFilter);
+			notifyFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+			notifyFilter.dbcc_classguid = GUID_DEVINTERFACE_USB_DEVICE;
+			
+			if (!RegisterClassA(&wincl))
+			{
+				DWORD le = GetLastError();
+				printf("RegisterClassA() failed [Error: %x]\r\n", le);
+				return;
+			}
+
+			hwnd = CreateWindowExA(WS_EX_TOPMOST, className, className, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
+			if (!hwnd)
+			{
+				DWORD le = GetLastError();
+				printf("CreateWindowExA() failed [Error: %x]\r\n", le);
+				goto cleanup;
+			}
+			
+            SetWindowLongPtrA( hwnd, GWLP_USERDATA, (LONG_PTR )this );
+
+			hDevNotify = RegisterDeviceNotificationA(hwnd, &notifyFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
+			if (!hDevNotify)
+			{
+				DWORD le = GetLastError();
+				printf("RegisterDeviceNotificationA() failed [Error: %x]\r\n", le);
+				goto cleanup;
+			}
+
+			MSG msg;
+			while (TRUE)
+			{
+				BOOL bRet = GetMessage(&msg, hwnd, 0, 0);
+				if ((bRet == 0) || (bRet == -1))
+				{
+					break;
+				}
+
+				TranslateMessage(&msg);
+				DispatchMessage(&msg);
+			}
+
+			// cleanup the resources
+			cleanup:
+
+			if (hwnd) {
+				if (!DestroyWindow(hwnd)) {
+					DWORD le = GetLastError();
+					printf("DestroyWindow() failed [Error: %x]\r\n", le);
+				}
+				hwnd = nullptr;
+			}
+			
+			if (!UnregisterClassA(wincl.lpszClassName, wincl.hInstance)) {
+				DWORD le = GetLastError();
+				printf("UnregisterClassA() failed [Error: %x]\r\n", le);
+			}
+
+
+			notify_func.Release();
+		});
+
+		return true;
+	}
+	void Stop()
+	{
+		if (isRunning)
+		{
+			isRunning = false;
+
+			if (hwnd) {
+				PostMessage(hwnd, WM_CLOSE, 0, 0);
+			}
+
+			poll_thread.join();
+		}
+	}
+
+	
+	void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state)
+	{
+		// dbcc_name:
+		// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
+		// convert to
+		// USB\Vid_04e8&Pid_503b\0002F9A9828E0F06
+		tstring szDevId = pDevInf->dbcc_name + 4;
+		auto idx = szDevId.rfind(_T('#'));
+
+		if (idx != tstring::npos)
+			szDevId.resize(idx);
+		std::replace(begin(szDevId), end(szDevId), _T('#'), _T('\\'));
+		auto to_upper = [](TCHAR ch) { return std::use_facet<std::ctype<TCHAR>>(std::locale()).toupper(ch); };
+		transform(begin(szDevId), end(szDevId), begin(szDevId), to_upper);
+
+		tstring szClass;
+		idx = szDevId.find(_T('\\'));
+		if (idx != tstring::npos)
+			szClass = szDevId.substr(0, idx);
+		// if we are adding device, we only need present devices
+		// otherwise, we need all devices
+		DWORD dwFlag = DBT_DEVICEARRIVAL != wParam ? DIGCF_ALLCLASSES : (DIGCF_ALLCLASSES | DIGCF_PRESENT);
+		HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, szClass.c_str(), NULL, dwFlag);
+		if (INVALID_HANDLE_VALUE == hDevInfo)
+		{
+			return;
+		}
+
+		SP_DEVINFO_DATA *pspDevInfoData = (SP_DEVINFO_DATA *)HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
+		if (pspDevInfoData)
+		{
+			pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
+			for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++)
+			{
+				DWORD nSize = 0;
+				TCHAR buf[MAX_PATH];
+
+				if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize))
+				{
+					break;
+				}
+				NormalizeSlashes(buf);
+
+				if (szDevId == buf)
+				{
+					DWORD DataT;
+					DWORD nSize;
+					DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+					DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
+
+					if (state == DeviceState_Connect)
+					{
+						std::string key = buf;
+						std::shared_ptr<ListResultItem_t> item = GetProperties(hDevInfo, pspDevInfoData, buf, MAX_PATH);
+
+						deviceMap.addItem(key, item);
+
+						DeviceAdded(item);
+					}
+					else
+					{
+						std::shared_ptr<ListResultItem_t> item = deviceMap.popItem(buf);
+						if (item == nullptr)
+						{
+							item = GetProperties(hDevInfo, pspDevInfoData, buf, MAX_PATH);
+						}
+
+						DeviceRemoved(item);
+					}
+
+					break;
+				}
+			}
+
+			HeapFree(GetProcessHeap(), 0, pspDevInfoData);
+		}
+
+		if (hDevInfo)
+		{
+			DllSetupDiDestroyDeviceInfoList(hDevInfo);
+		}
+	}
+
+private:
+	/**********************************
+ 	 * Local Functions
+	 **********************************/
+	std::shared_ptr<ListResultItem_t> GetProperties(HDEVINFO hDevInfo, SP_DEVINFO_DATA *pspDevInfoData, TCHAR *buf, DWORD buffSize)
+	{
+		std::shared_ptr<ListResultItem_t> item(new ListResultItem_t);
+
+		DWORD DataT;
+		DWORD nSize;
+		static int dummy = 1;
+
+		item->locationId = 0;
+		item->deviceAddress = dummy++;
+
+		// device found
+		if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, buffSize, &nSize))
+		{
+			item->deviceName = Utf8Encode(buf);
+		}
+		else if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize))
+		{
+			item->deviceName = Utf8Encode(buf);
+		}
+		if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, buffSize, &nSize))
+		{
+			item->manufacturer = Utf8Encode(buf);
+		}
+		if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, buffSize, &nSize))
+		{
+			// Use this to extract VID / PID
+			extractVidPid(buf, item.get());
+		}
+
+		// Extract Serial Number
+		//
+		// Format: <device-ID>\<instance-specific-ID>
+		//
+		// Ex. `USB\VID_2109&PID_8110\5&376ABA2D&0&21`
+		//  - `<device-ID>`: `USB\VID_2109&PID_8110`
+		//  - `<instance-specific-ID>`: `5&376ABA2D&0&21`
+		//
+		// [Device instance IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-instance-ids) ->
+		//  - [Device IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-ids) -> [Hardware IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/hardware-ids) -> [Device identifier formats](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-identifier-formats) -> [Identifiers for USB devices](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-usb-devices)
+		//     - [Standard USB Identifiers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/standard-usb-identifiers)
+		//     - [Special USB Identifiers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/special-usb-identifiers)
+		//  - [Instance specific ID](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/instance-ids)
+		DWORD dwCapabilities = 0x0;
+		if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_CAPABILITIES, &DataT, (PBYTE)&dwCapabilities, sizeof(dwCapabilities), &nSize))
+		{
+			if ((dwCapabilities & CM_DEVCAP_UNIQUEID) == CM_DEVCAP_UNIQUEID)
+			{
+				if (DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, buffSize, &nSize))
+				{
+					string deviceInstanceId = buf;
+					size_t serialNumberIndex = deviceInstanceId.find_last_of("\\");
+					if (serialNumberIndex != string::npos)
+					{
+						item->serialNumber = deviceInstanceId.substr(serialNumberIndex + 1);
+					}
+				}
+			}
+		}
+
+		return item;
+	}
+
+	void BuildInitialDeviceList()
+	{
+		DWORD dwFlag = (DIGCF_ALLCLASSES | DIGCF_PRESENT);
+		HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, "USB", NULL, dwFlag);
+
+		if (INVALID_HANDLE_VALUE == hDevInfo)
+		{
+			return;
+		}
+
+		SP_DEVINFO_DATA *pspDevInfoData = (SP_DEVINFO_DATA *)HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
+		if (pspDevInfoData)
+		{
+			pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
+			for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++)
+			{
+				DWORD nSize = 0;
+				TCHAR buf[MAX_PATH];
+
+				if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize))
+				{
+					break;
+				}
+				NormalizeSlashes(buf);
+
+				DWORD DataT;
+				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
+				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
+
+				std::string key = buf;
+				auto item = GetProperties(hDevInfo, pspDevInfoData, buf, MAX_PATH);
+				deviceMap.addItem(key, item);
+			}
+
+			HeapFree(GetProcessHeap(), 0, pspDevInfoData);
+		}
+
+		if (hDevInfo)
+		{
+			DllSetupDiDestroyDeviceInfoList(hDevInfo);
+		}
+	}
+
+	/**********************************
+	 * Local Variables
+	 **********************************/
+	std::thread poll_thread;
+
+	std::atomic<bool> isRunning = {false};
+
+public:
+	HWND hwnd;
+	HDEVNOTIFY hDevNotify;
+};
+
+void InitializeDetection(Napi::Env &env, Napi::Object &target)
+{
+	WindowsDetection::Initialize(env, target);
+}
+
 LRESULT CALLBACK DetectCallback(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-	if (msg == WM_DEVICECHANGE)
-	{
-		if (DBT_DEVICEARRIVAL == wParam || DBT_DEVICEREMOVECOMPLETE == wParam)
+	WindowsDetection * parent = (WindowsDetection *)GetWindowLongPtrA( hwnd, GWLP_USERDATA );
+	if (parent != nullptr) {
+		if (msg == WM_DEVICECHANGE)
 		{
-			PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
-			PDEV_BROADCAST_DEVICEINTERFACE pDevInf;
-
-			if (pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+			if (DBT_DEVICEARRIVAL == wParam || DBT_DEVICEREMOVECOMPLETE == wParam)
 			{
-				pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
-				UpdateDevice(pDevInf, wParam, (DBT_DEVICEARRIVAL == wParam) ? DeviceState_Connect : DeviceState_Disconnect);
+				PDEV_BROADCAST_HDR pHdr = (PDEV_BROADCAST_HDR)lParam;
+				PDEV_BROADCAST_DEVICEINTERFACE pDevInf;
+
+				if (pHdr->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+				{
+					pDevInf = (PDEV_BROADCAST_DEVICEINTERFACE)pHdr;
+					parent->UpdateDevice(pDevInf, wParam, (DBT_DEVICEARRIVAL == wParam) ? DeviceState_Connect : DeviceState_Disconnect);
+				}
 			}
+		} else if (msg == WM_CLOSE) {
+			if (!UnregisterDeviceNotification(parent->hDevNotify))
+			{
+				DWORD le = GetLastError();
+				printf("UnregisterDeviceNotification() failed [Error: %x]\r\n", le);
+			}
+			if (!DestroyWindow(parent->hwnd)) {
+				DWORD le = GetLastError();
+				printf("DestroyWindow() failed [Error: %x]\r\n", le);
+			}
+			parent->hwnd = nullptr;
+		} else if (msg == WM_DESTROY) {
+        	PostQuitMessage(0);
 		}
 	}
 
 	return 1;
-}
-
-DWORD WINAPI ListenerThread(LPVOID lpParam)
-{
-	char className[MAX_THREAD_WINDOW_NAME];
-	_snprintf_s(className, MAX_THREAD_WINDOW_NAME, "ListnerThreadUsbDetection_%d", GetCurrentThreadId());
-
-	WNDCLASSA wincl = {0};
-	wincl.hInstance = GetModuleHandle(0);
-	wincl.lpszClassName = className;
-	wincl.lpfnWndProc = DetectCallback;
-
-	if (!RegisterClassA(&wincl))
-	{
-		DWORD le = GetLastError();
-		printf("RegisterClassA() failed [Error: %x]\r\n", le);
-		return 1;
-	}
-
-	HWND hwnd = CreateWindowExA(WS_EX_TOPMOST, className, className, 0, 0, 0, 0, 0, NULL, 0, 0, 0);
-	if (!hwnd)
-	{
-		DWORD le = GetLastError();
-		printf("CreateWindowExA() failed [Error: %x]\r\n", le);
-		return 1;
-	}
-
-	DEV_BROADCAST_DEVICEINTERFACE_A notifyFilter = {0};
-	notifyFilter.dbcc_size = sizeof(notifyFilter);
-	notifyFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-	notifyFilter.dbcc_classguid = GUID_DEVINTERFACE_USB_DEVICE;
-
-	HDEVNOTIFY hDevNotify = RegisterDeviceNotificationA(hwnd, &notifyFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
-	if (!hDevNotify)
-	{
-		DWORD le = GetLastError();
-		printf("RegisterDeviceNotificationA() failed [Error: %x]\r\n", le);
-		return 1;
-	}
-
-	MSG msg;
-	while (TRUE)
-	{
-		BOOL bRet = GetMessage(&msg, hwnd, 0, 0);
-		if ((bRet == 0) || (bRet == -1))
-		{
-			break;
-		}
-
-		TranslateMessage(&msg);
-		DispatchMessage(&msg);
-	}
-
-	return 0;
-}
-
-void BuildInitialDeviceList()
-{
-	DWORD dwFlag = (DIGCF_ALLCLASSES | DIGCF_PRESENT);
-	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, "USB", NULL, dwFlag);
-
-	if (INVALID_HANDLE_VALUE == hDevInfo)
-	{
-		return;
-	}
-
-	SP_DEVINFO_DATA *pspDevInfoData = (SP_DEVINFO_DATA *)HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
-	if (pspDevInfoData)
-	{
-		pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
-		for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++)
-		{
-			DWORD nSize = 0;
-			TCHAR buf[MAX_PATH];
-
-			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize))
-			{
-				break;
-			}
-			NormalizeSlashes(buf);
-
-			ListResultItem_t *item = new ListResultItem_t();
-
-			DWORD DataT;
-			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
-			DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
-
-			AddItemToList(buf, item);
-			ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, item);
-		}
-
-		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
-	}
-
-	if (hDevInfo)
-	{
-		DllSetupDiDestroyDeviceInfoList(hDevInfo);
-	}
-}
-
-void ExtractDeviceInfo(HDEVINFO hDevInfo, SP_DEVINFO_DATA *pspDevInfoData, TCHAR *buf, DWORD buffSize, ListResultItem_t *resultItem)
-{
-
-	DWORD DataT;
-	DWORD nSize;
-	static int dummy = 1;
-
-	resultItem->locationId = 0;
-	resultItem->deviceAddress = dummy++;
-
-	// device found
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_FRIENDLYNAME, &DataT, (PBYTE)buf, buffSize, &nSize))
-	{
-		resultItem->deviceName = Utf8Encode(buf);
-	}
-	else if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_DEVICEDESC, &DataT, (PBYTE)buf, buffSize, &nSize))
-	{
-		resultItem->deviceName = Utf8Encode(buf);
-	}
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_MFG, &DataT, (PBYTE)buf, buffSize, &nSize))
-	{
-		resultItem->manufacturer = Utf8Encode(buf);
-	}
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)buf, buffSize, &nSize))
-	{
-		// Use this to extract VID / PID
-		extractVidPid(buf, resultItem);
-	}
-
-	// Extract Serial Number
-	//
-	// Format: <device-ID>\<instance-specific-ID>
-	//
-	// Ex. `USB\VID_2109&PID_8110\5&376ABA2D&0&21`
-	//  - `<device-ID>`: `USB\VID_2109&PID_8110`
-	//  - `<instance-specific-ID>`: `5&376ABA2D&0&21`
-	//
-	// [Device instance IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-instance-ids) ->
-	//  - [Device IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-ids) -> [Hardware IDs](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/hardware-ids) -> [Device identifier formats](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/device-identifier-formats) -> [Identifiers for USB devices](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-usb-devices)
-	//     - [Standard USB Identifiers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/standard-usb-identifiers)
-	//     - [Special USB Identifiers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/special-usb-identifiers)
-	//  - [Instance specific ID](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/instance-ids)
-	DWORD dwCapabilities = 0x0;
-	if (DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_CAPABILITIES, &DataT, (PBYTE)&dwCapabilities, sizeof(dwCapabilities), &nSize))
-	{
-		if ((dwCapabilities & CM_DEVCAP_UNIQUEID) == CM_DEVCAP_UNIQUEID)
-		{
-			if (DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, buffSize, &nSize))
-			{
-				string deviceInstanceId = buf;
-				size_t serialNumberIndex = deviceInstanceId.find_last_of("\\");
-				if (serialNumberIndex != string::npos)
-				{
-					resultItem->serialNumber = deviceInstanceId.substr(serialNumberIndex + 1);
-				}
-			}
-		}
-	}
-}
-
-void UpdateDevice(PDEV_BROADCAST_DEVICEINTERFACE pDevInf, WPARAM wParam, DeviceState_t state)
-{
-	// dbcc_name:
-	// \\?\USB#Vid_04e8&Pid_503b#0002F9A9828E0F06#{a5dcbf10-6530-11d2-901f-00c04fb951ed}
-	// convert to
-	// USB\Vid_04e8&Pid_503b\0002F9A9828E0F06
-	tstring szDevId = pDevInf->dbcc_name + 4;
-	auto idx = szDevId.rfind(_T('#'));
-
-	if (idx != tstring::npos)
-		szDevId.resize(idx);
-	std::replace(begin(szDevId), end(szDevId), _T('#'), _T('\\'));
-	auto to_upper = [](TCHAR ch) { return std::use_facet<std::ctype<TCHAR>>(std::locale()).toupper(ch); };
-	transform(begin(szDevId), end(szDevId), begin(szDevId), to_upper);
-
-	tstring szClass;
-	idx = szDevId.find(_T('\\'));
-	if (idx != tstring::npos)
-		szClass = szDevId.substr(0, idx);
-	// if we are adding device, we only need present devices
-	// otherwise, we need all devices
-	DWORD dwFlag = DBT_DEVICEARRIVAL != wParam ? DIGCF_ALLCLASSES : (DIGCF_ALLCLASSES | DIGCF_PRESENT);
-	HDEVINFO hDevInfo = DllSetupDiGetClassDevs(NULL, szClass.c_str(), NULL, dwFlag);
-	if (INVALID_HANDLE_VALUE == hDevInfo)
-	{
-		return;
-	}
-
-	SP_DEVINFO_DATA *pspDevInfoData = (SP_DEVINFO_DATA *)HeapAlloc(GetProcessHeap(), 0, sizeof(SP_DEVINFO_DATA));
-	if (pspDevInfoData)
-	{
-		pspDevInfoData->cbSize = sizeof(SP_DEVINFO_DATA);
-		for (int i = 0; DllSetupDiEnumDeviceInfo(hDevInfo, i, pspDevInfoData); i++)
-		{
-			DWORD nSize = 0;
-			TCHAR buf[MAX_PATH];
-
-			if (!DllSetupDiGetDeviceInstanceId(hDevInfo, pspDevInfoData, buf, sizeof(buf), &nSize))
-			{
-				break;
-			}
-			NormalizeSlashes(buf);
-
-			if (szDevId == buf)
-			{
-				WaitForSingleObject(deviceChangedSentEvent, INFINITE);
-
-				DWORD DataT;
-				DWORD nSize;
-				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_LOCATION_INFORMATION, &DataT, (PBYTE)buf, MAX_PATH, &nSize);
-				DllSetupDiGetDeviceRegistryProperty(hDevInfo, pspDevInfoData, SPDRP_HARDWAREID, &DataT, (PBYTE)(buf + nSize - 1), MAX_PATH - nSize, &nSize);
-
-				if (state == DeviceState_Connect)
-				{
-					ListResultItem_t *device = new ListResultItem_t();
-
-					AddItemToList(buf, device);
-					ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, device);
-
-					currentDevice = &device->deviceParams;
-					isAdded = true;
-				}
-				else
-				{
-
-					ListResultItem_t *item = NULL;
-					if (IsItemAlreadyStored(buf))
-					{
-						ListResultItem_t *deviceItem = PopItemFromList(buf);
-						if (deviceItem)
-						{
-							item = CopyElement(deviceItem);
-							delete deviceItem;
-						}
-					}
-
-					if (item == NULL)
-					{
-						item = new ListResultItem_t();
-						ExtractDeviceInfo(hDevInfo, pspDevInfoData, buf, MAX_PATH, item);
-					}
-					currentDevice = item;
-					isAdded = false;
-				}
-
-				break;
-			}
-		}
-
-		HeapFree(GetProcessHeap(), 0, pspDevInfoData);
-	}
-
-	if (hDevInfo)
-	{
-		DllSetupDiDestroyDeviceInfoList(hDevInfo);
-	}
-
-	SetEvent(deviceChangedRegisteredEvent);
-}
-
-std::string Utf8Encode(const std::string &str)
-{
-	if (str.empty())
-	{
-		return std::string();
-	}
-
-	//System default code page to wide character
-	int wstr_size = MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, NULL, 0);
-	std::wstring wstr_tmp(wstr_size, 0);
-	MultiByteToWideChar(CP_ACP, 0, str.c_str(), -1, &wstr_tmp[0], wstr_size);
-
-	//Wide character to Utf8
-	int str_size = WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), NULL, 0, NULL, NULL);
-	std::string str_utf8(str_size, 0);
-	WideCharToMultiByte(CP_UTF8, 0, &wstr_tmp[0], (int)wstr_tmp.size(), &str_utf8[0], str_size, NULL, NULL);
-
-	return str_utf8;
 }

--- a/src/deviceList.cpp
+++ b/src/deviceList.cpp
@@ -1,18 +1,11 @@
-#include <map>
-#include <string.h>
-#include <stdio.h>
-#include <memory>
-
 #include "deviceList.h"
 
-std::map<std::string, std::shared_ptr<ListResultItem_t>> deviceMap;
-
-void AddItemToList(char *key, std::shared_ptr<ListResultItem_t> item)
+void DeviceMap::addItem(std::string key, std::shared_ptr<ListResultItem_t> item)
 {
 	deviceMap.insert(std::pair<std::string, std::shared_ptr<ListResultItem_t>>(key, item));
 }
 
-std::shared_ptr<ListResultItem_t> PopItemFromList(char *key)
+std::shared_ptr<ListResultItem_t> DeviceMap::popItem(std::string key)
 {
 	auto it = deviceMap.find(key);
 	if (it == deviceMap.end())
@@ -27,30 +20,21 @@ std::shared_ptr<ListResultItem_t> PopItemFromList(char *key)
 	}
 }
 
-// ListResultItem_t *CopyElement(ListResultItem_t *item)
-// {
-// 	ListResultItem_t *dst = new ListResultItem_t();
-// 	dst->locationId = item->locationId;
-// 	dst->vendorId = item->vendorId;
-// 	dst->productId = item->productId;
-// 	dst->deviceName = item->deviceName;
-// 	dst->manufacturer = item->manufacturer;
-// 	dst->serialNumber = item->serialNumber;
-// 	dst->deviceAddress = item->deviceAddress;
-
-// 	return dst;
-// }
-
-void CreateFilteredList(std::list<std::shared_ptr<ListResultItem_t>> *filteredList, int vid, int pid)
+std::list<std::shared_ptr<ListResultItem_t>> DeviceMap::filterItems(int vid, int pid)
 {
+	std::list<std::shared_ptr<ListResultItem_t>> list;
 	for (auto it = deviceMap.begin(); it != deviceMap.end(); ++it)
 	{
 		std::shared_ptr<ListResultItem_t> item = it->second;
 
 		if (
-			((vid != 0 && pid != 0) && (vid == item->vendorId && pid == item->productId)) || ((vid != 0 && pid == 0) && vid == item->vendorId) || (vid == 0 && pid == 0))
+			((vid != 0 && pid != 0) && (vid == item->vendorId && pid == item->productId)) ||
+			((vid != 0 && pid == 0) && vid == item->vendorId) ||
+			(vid == 0 && pid == 0))
 		{
-			(*filteredList).push_back(item);
+			list.push_back(item);
 		}
 	}
+
+	return list;
 }

--- a/src/deviceList.cpp
+++ b/src/deviceList.cpp
@@ -3,7 +3,7 @@
 void DeviceMap::addItem(std::string key, std::shared_ptr<ListResultItem_t> item)
 {
 	std::lock_guard<std::mutex> guard(mapLock);
-	deviceMap.insert(std::pair<std::string, std::shared_ptr<ListResultItem_t>>(key, item));
+	deviceMap.insert(std::pair<std::string, std::shared_ptr<ListResultItem_t> >(key, item));
 }
 
 std::shared_ptr<ListResultItem_t> DeviceMap::popItem(std::string key)
@@ -22,9 +22,9 @@ std::shared_ptr<ListResultItem_t> DeviceMap::popItem(std::string key)
 	}
 }
 
-std::list<std::shared_ptr<ListResultItem_t>> DeviceMap::filterItems(int vid, int pid)
+std::list<std::shared_ptr<ListResultItem_t> > DeviceMap::filterItems(int vid, int pid)
 {
-	std::list<std::shared_ptr<ListResultItem_t>> list;
+	std::list<std::shared_ptr<ListResultItem_t> > list;
 	std::lock_guard<std::mutex> guard(mapLock);
 	for (auto it = deviceMap.begin(); it != deviceMap.end(); ++it)
 	{
@@ -38,6 +38,22 @@ std::list<std::shared_ptr<ListResultItem_t>> DeviceMap::filterItems(int vid, int
 			list.push_back(item);
 		}
 	}
+
+	return list;
+}
+
+std::list<std::shared_ptr<ListResultItem_t> > DeviceMap::popAll()
+{
+	std::list<std::shared_ptr<ListResultItem_t> > list;
+	std::lock_guard<std::mutex> guard(mapLock);
+
+	for (auto it = deviceMap.begin(); it != deviceMap.end(); ++it)
+	{
+		std::shared_ptr<ListResultItem_t> item = it->second;
+		list.push_back(item);
+	}
+
+	deviceMap.clear();
 
 	return list;
 }

--- a/src/deviceList.cpp
+++ b/src/deviceList.cpp
@@ -2,11 +2,13 @@
 
 void DeviceMap::addItem(std::string key, std::shared_ptr<ListResultItem_t> item)
 {
+	std::lock_guard<std::mutex> guard(mapLock);
 	deviceMap.insert(std::pair<std::string, std::shared_ptr<ListResultItem_t>>(key, item));
 }
 
 std::shared_ptr<ListResultItem_t> DeviceMap::popItem(std::string key)
 {
+	std::lock_guard<std::mutex> guard(mapLock);
 	auto it = deviceMap.find(key);
 	if (it == deviceMap.end())
 	{
@@ -23,6 +25,7 @@ std::shared_ptr<ListResultItem_t> DeviceMap::popItem(std::string key)
 std::list<std::shared_ptr<ListResultItem_t>> DeviceMap::filterItems(int vid, int pid)
 {
 	std::list<std::shared_ptr<ListResultItem_t>> list;
+	std::lock_guard<std::mutex> guard(mapLock);
 	for (auto it = deviceMap.begin(); it != deviceMap.end(); ++it)
 	{
 		std::shared_ptr<ListResultItem_t> item = it->second;

--- a/src/deviceList.cpp
+++ b/src/deviceList.cpp
@@ -27,12 +27,6 @@ std::shared_ptr<ListResultItem_t> PopItemFromList(char *key)
 	}
 }
 
-bool IsItemAlreadyStored(char *key)
-{
-	auto it = deviceMap.find(key);
-	return it != deviceMap.end();
-}
-
 // ListResultItem_t *CopyElement(ListResultItem_t *item)
 // {
 // 	ListResultItem_t *dst = new ListResultItem_t();

--- a/src/deviceList.cpp
+++ b/src/deviceList.cpp
@@ -4,72 +4,62 @@
 
 #include "deviceList.h"
 
-
 using namespace std;
 
-map<string, DeviceItem_t*> deviceMap;
+std::map<string, ListResultItem_t *> deviceMap;
 
-void AddItemToList(char* key, DeviceItem_t * item) {
-	item->SetKey(key);
-	deviceMap.insert(pair<string, DeviceItem_t*>(item->GetKey(), item));
+void AddItemToList(char *key, ListResultItem_t *item)
+{
+	deviceMap.insert(std::pair<string, ListResultItem_t *>(key, item));
 }
 
-void RemoveItemFromList(DeviceItem_t* item) {
-	deviceMap.erase(item->GetKey());
-}
-
-DeviceItem_t* GetItemFromList(char* key) {
-	map<string, DeviceItem_t*>::iterator it;
-
-	it = deviceMap.find(key);
-	if(it == deviceMap.end()) {
+ListResultItem_t *PopItemFromList(char *key)
+{
+	auto it = deviceMap.find(key);
+	if (it == deviceMap.end())
+	{
 		return NULL;
 	}
-	else {
-		return it->second;
+	else
+	{
+		ListResultItem_t *item = it->second;
+		deviceMap.erase(it);
+		return item;
 	}
 }
 
-bool IsItemAlreadyStored(char* key) {
-	map<string, DeviceItem_t*>::iterator it;
-
-	it = deviceMap.find(key);
-	if(it == deviceMap.end()) {
-		return false;
-	}
-	else {
-		return true;
-	}
-
-	return true;
+bool IsItemAlreadyStored(char *key)
+{
+	auto it = deviceMap.find(key);
+	return it != deviceMap.end();
 }
 
-ListResultItem_t* CopyElement(ListResultItem_t* item) {
-    ListResultItem_t* dst = new ListResultItem_t();
-    dst->locationId     =   item->locationId;
-    dst->vendorId       =   item->vendorId;
-    dst->productId      =   item->productId;
-    dst->deviceName     =   item->deviceName;
-    dst->manufacturer   =   item->manufacturer;
-    dst->serialNumber   =   item->serialNumber;
-    dst->deviceAddress  =   item->deviceAddress;
+ListResultItem_t *CopyElement(ListResultItem_t *item)
+{
+	ListResultItem_t *dst = new ListResultItem_t();
+	dst->locationId = item->locationId;
+	dst->vendorId = item->vendorId;
+	dst->productId = item->productId;
+	dst->deviceName = item->deviceName;
+	dst->manufacturer = item->manufacturer;
+	dst->serialNumber = item->serialNumber;
+	dst->deviceAddress = item->deviceAddress;
 
-    return dst;
+	return dst;
 }
 
-void CreateFilteredList(list<ListResultItem_t*> *filteredList, int vid, int pid) {
-	map<string, DeviceItem_t*>::iterator it;
+void CreateFilteredList(list<ListResultItem_t *> *filteredList, int vid, int pid)
+{
+	map<string, ListResultItem_t *>::iterator it;
 
-	for (it = deviceMap.begin(); it != deviceMap.end(); ++it) {
-    	DeviceItem_t* item = it->second;
+	for (it = deviceMap.begin(); it != deviceMap.end(); ++it)
+	{
+		ListResultItem_t *item = it->second;
 
-        if (
-        	((	vid != 0 && pid != 0) && (vid == item->deviceParams.vendorId && pid == item->deviceParams.productId))
-        	|| 	((vid != 0 && pid == 0) && vid == item->deviceParams.vendorId)
-        	||	(vid == 0 && pid == 0)
-    	) {
-        	(*filteredList).push_back(CopyElement(&item->deviceParams));
-        }
-
-    }
+		if (
+			((vid != 0 && pid != 0) && (vid == item->vendorId && pid == item->productId)) || ((vid != 0 && pid == 0) && vid == item->vendorId) || (vid == 0 && pid == 0))
+		{
+			(*filteredList).push_back(CopyElement(item));
+		}
+	}
 }

--- a/src/deviceList.cpp
+++ b/src/deviceList.cpp
@@ -1,28 +1,27 @@
 #include <map>
 #include <string.h>
 #include <stdio.h>
+#include <memory>
 
 #include "deviceList.h"
 
-using namespace std;
+std::map<std::string, std::shared_ptr<ListResultItem_t>> deviceMap;
 
-std::map<string, ListResultItem_t *> deviceMap;
-
-void AddItemToList(char *key, ListResultItem_t *item)
+void AddItemToList(char *key, std::shared_ptr<ListResultItem_t> item)
 {
-	deviceMap.insert(std::pair<string, ListResultItem_t *>(key, item));
+	deviceMap.insert(std::pair<std::string, std::shared_ptr<ListResultItem_t>>(key, item));
 }
 
-ListResultItem_t *PopItemFromList(char *key)
+std::shared_ptr<ListResultItem_t> PopItemFromList(char *key)
 {
 	auto it = deviceMap.find(key);
 	if (it == deviceMap.end())
 	{
-		return NULL;
+		return nullptr;
 	}
 	else
 	{
-		ListResultItem_t *item = it->second;
+		std::shared_ptr<ListResultItem_t> item = it->second;
 		deviceMap.erase(it);
 		return item;
 	}
@@ -34,32 +33,30 @@ bool IsItemAlreadyStored(char *key)
 	return it != deviceMap.end();
 }
 
-ListResultItem_t *CopyElement(ListResultItem_t *item)
+// ListResultItem_t *CopyElement(ListResultItem_t *item)
+// {
+// 	ListResultItem_t *dst = new ListResultItem_t();
+// 	dst->locationId = item->locationId;
+// 	dst->vendorId = item->vendorId;
+// 	dst->productId = item->productId;
+// 	dst->deviceName = item->deviceName;
+// 	dst->manufacturer = item->manufacturer;
+// 	dst->serialNumber = item->serialNumber;
+// 	dst->deviceAddress = item->deviceAddress;
+
+// 	return dst;
+// }
+
+void CreateFilteredList(std::list<std::shared_ptr<ListResultItem_t>> *filteredList, int vid, int pid)
 {
-	ListResultItem_t *dst = new ListResultItem_t();
-	dst->locationId = item->locationId;
-	dst->vendorId = item->vendorId;
-	dst->productId = item->productId;
-	dst->deviceName = item->deviceName;
-	dst->manufacturer = item->manufacturer;
-	dst->serialNumber = item->serialNumber;
-	dst->deviceAddress = item->deviceAddress;
-
-	return dst;
-}
-
-void CreateFilteredList(list<ListResultItem_t *> *filteredList, int vid, int pid)
-{
-	map<string, ListResultItem_t *>::iterator it;
-
-	for (it = deviceMap.begin(); it != deviceMap.end(); ++it)
+	for (auto it = deviceMap.begin(); it != deviceMap.end(); ++it)
 	{
-		ListResultItem_t *item = it->second;
+		std::shared_ptr<ListResultItem_t> item = it->second;
 
 		if (
 			((vid != 0 && pid != 0) && (vid == item->vendorId && pid == item->productId)) || ((vid != 0 && pid == 0) && vid == item->vendorId) || (vid == 0 && pid == 0))
 		{
-			(*filteredList).push_back(CopyElement(item));
+			(*filteredList).push_back(item);
 		}
 	}
 }

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -3,7 +3,8 @@
 
 #include <string>
 #include <list>
-
+#include <map>
+#include <memory>
 typedef struct
 {
 public:
@@ -22,9 +23,16 @@ typedef enum _DeviceState_t
 	DeviceState_Disconnect,
 } DeviceState_t;
 
-void AddItemToList(char *key, std::shared_ptr<ListResultItem_t> item);
-std::shared_ptr<ListResultItem_t> PopItemFromList(char *key);
-// ListResultItem_t *CopyElement(ListResultItem_t *item);
-void CreateFilteredList(std::list<ListResultItem_t *> *filteredList, int vid, int pid);
+class DeviceMap
+{
+public:
+	void addItem(std::string key, std::shared_ptr<ListResultItem_t> item);
+	std::shared_ptr<ListResultItem_t> popItem(std::string key);
+
+	std::list<std::shared_ptr<ListResultItem_t>> filterItems(int vid, int pid);
+
+private:
+	std::map<std::string, std::shared_ptr<ListResultItem_t>> deviceMap;
+};
 
 #endif

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <memory>
+
 typedef struct
 {
 public:

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 
 typedef struct
 {
@@ -34,6 +35,7 @@ public:
 
 private:
 	std::map<std::string, std::shared_ptr<ListResultItem_t>> deviceMap;
+	std::mutex mapLock;
 };
 
 #endif

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -22,10 +22,10 @@ typedef enum _DeviceState_t
 	DeviceState_Disconnect,
 } DeviceState_t;
 
-void AddItemToList(char *key, ListResultItem_t *item);
+void AddItemToList(char *key, std::shared_ptr<ListResultItem_t> item);
 bool IsItemAlreadyStored(char *identifier);
-ListResultItem_t *PopItemFromList(char *key);
-ListResultItem_t *CopyElement(ListResultItem_t *item);
+std::shared_ptr<ListResultItem_t> PopItemFromList(char *key);
+// ListResultItem_t *CopyElement(ListResultItem_t *item);
 void CreateFilteredList(std::list<ListResultItem_t *> *filteredList, int vid, int pid);
 
 #endif

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <mutex>
 
-typedef struct
+struct ListResultItem_t
 {
 public:
 	int locationId;
@@ -17,13 +17,13 @@ public:
 	std::string manufacturer;
 	std::string serialNumber;
 	int deviceAddress;
-} ListResultItem_t;
+};
 
-typedef enum _DeviceState_t
+enum DeviceState_t
 {
 	DeviceState_Connect,
 	DeviceState_Disconnect,
-} DeviceState_t;
+};
 
 class DeviceMap
 {
@@ -31,10 +31,10 @@ public:
 	void addItem(std::string key, std::shared_ptr<ListResultItem_t> item);
 	std::shared_ptr<ListResultItem_t> popItem(std::string key);
 
-	std::list<std::shared_ptr<ListResultItem_t>> filterItems(int vid, int pid);
+	std::list<std::shared_ptr<ListResultItem_t> > filterItems(int vid, int pid);
 
 private:
-	std::map<std::string, std::shared_ptr<ListResultItem_t>> deviceMap;
+	std::map<std::string, std::shared_ptr<ListResultItem_t> > deviceMap;
 	std::mutex mapLock;
 };
 

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -23,7 +23,6 @@ typedef enum _DeviceState_t
 } DeviceState_t;
 
 void AddItemToList(char *key, std::shared_ptr<ListResultItem_t> item);
-bool IsItemAlreadyStored(char *identifier);
 std::shared_ptr<ListResultItem_t> PopItemFromList(char *key);
 // ListResultItem_t *CopyElement(ListResultItem_t *item);
 void CreateFilteredList(std::list<ListResultItem_t *> *filteredList, int vid, int pid);

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -17,6 +17,7 @@ public:
 	std::string manufacturer;
 	std::string serialNumber;
 	int deviceAddress;
+	void *data;
 };
 
 enum DeviceState_t
@@ -32,6 +33,8 @@ public:
 	std::shared_ptr<ListResultItem_t> popItem(std::string key);
 
 	std::list<std::shared_ptr<ListResultItem_t> > filterItems(int vid, int pid);
+
+	std::list<std::shared_ptr<ListResultItem_t> > popAll();
 
 private:
 	std::map<std::string, std::shared_ptr<ListResultItem_t> > deviceMap;

--- a/src/deviceList.h
+++ b/src/deviceList.h
@@ -4,60 +4,28 @@
 #include <string>
 #include <list>
 
-typedef struct {
-	public:
-		int locationId;
-		int vendorId;
-		int productId;
-		std::string deviceName;
-		std::string manufacturer;
-		std::string serialNumber;
-		int deviceAddress;
+typedef struct
+{
+public:
+	int locationId;
+	int vendorId;
+	int productId;
+	std::string deviceName;
+	std::string manufacturer;
+	std::string serialNumber;
+	int deviceAddress;
 } ListResultItem_t;
 
-typedef enum  _DeviceState_t {
+typedef enum _DeviceState_t
+{
 	DeviceState_Connect,
 	DeviceState_Disconnect,
 } DeviceState_t;
 
-typedef struct _DeviceItem_t {
-	ListResultItem_t deviceParams;
-	DeviceState_t deviceState;
-
-	private:
-		char* key;
-
-
-	public:
-		_DeviceItem_t() {
-			key = NULL;
-		}
-
-		~_DeviceItem_t() {
-			if(this->key != NULL) {
-				delete this->key;
-			}
-		}
-
-		void SetKey(char* key) {
-			if(this->key != NULL) {
-				delete this->key;
-			}
-			this->key = new char[strlen(key) + 1];
-			memcpy(this->key, key, strlen(key) + 1);
-		}
-
-		char* GetKey() {
-			return this->key;
-		}
-} DeviceItem_t;
-
-
-void AddItemToList(char* key, DeviceItem_t * item);
-void RemoveItemFromList(DeviceItem_t* item);
-bool IsItemAlreadyStored(char* identifier);
-DeviceItem_t* GetItemFromList(char* key);
-ListResultItem_t* CopyElement(ListResultItem_t* item);
-void CreateFilteredList(std::list<ListResultItem_t*>* filteredList, int vid, int pid);
+void AddItemToList(char *key, ListResultItem_t *item);
+bool IsItemAlreadyStored(char *identifier);
+ListResultItem_t *PopItemFromList(char *key);
+ListResultItem_t *CopyElement(ListResultItem_t *item);
+void CreateFilteredList(std::list<ListResultItem_t *> *filteredList, int vid, int pid);
 
 #endif


### PR DESCRIPTION
fixes: #102, #119, #57, #116, #42, #53
replaces: #113, #125, #118

I haven't fixed up mac or windows yet, but shall get to that soon.

This has become quite a large rewrite due to how parts were written.
I have tried to split it across commits in different phases to make it easier to understand.

Support for anything below node 10 has been dropped, due to limitations of napi. I dont see this as a problem as everything still officially supported is covered. The benefit to this is that the builds are [guaranteed to work in future versions of node](https://nodejs.org/api/n-api.html#n_api_n_api_version_matrix) without needing to be recompiled. There is also no need to recompile for electron, as it will use the same binaries

All the usages of `#include<uv.h>` have to be replaced as they [are not abi safe](https://nodejs.org/api/n-api.html#n_api_implications_of_abi_stability). Because of this I have pretty much rewritten the contents of `detection_linux.cpp`, taking inspiration and reusable snippets from the old file.

To be context aware, [nothing can be in the global scope](https://napi.inspiredware.com/special-topics/context-awareness.html#Multiple-loading-and-unloading) so various bits had to be refactored to remove any use of statics.

For now this change is not trying to optimise for multiple threads, so is initialising a new listener/watcher for each thread. This can be improved on later.

For now this I have avoided any api changes, but it would be nice to make some to better reflect ownership of the listener. One concern I have is that if two libraries uses this and one calls stopMonitoring, that will stop events for the other or the root application. It would be nice to be able to scope listeners instead, by returning something from the start function that will allow for manual stopping and restarting, and will auto-stop when it gets garbage collected.