### PR TITLE
Fixed a crash after stopMonitoring on Linux in Electron

### DIFF
--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -89,16 +89,13 @@ void Stop() {
 		return;
 	}
 
-	isRunning = false;
-
 	uv_mutex_destroy(&notify_mutex);
 	uv_signal_stop(&int_signal);
 	uv_signal_stop(&term_signal);
 	uv_close((uv_handle_t *) &async_handler, NULL);
 	uv_cond_destroy(&notifyDeviceHandled);
-
-	udev_monitor_unref(mon);
-	udev_unref(udev);
+	
+	isRunning = false;
 }
 
 void InitDetection() {
@@ -244,6 +241,9 @@ static void cbWork(uv_work_t *req) {
 }
 
 static void cbAfter(uv_work_t *req, int status) {
+	udev_monitor_unref(mon);
+	udev_unref(udev);
+
 	Stop();
 }
 


### PR DESCRIPTION
Hi! 👋 

Thanks for the library, it's awesome and seems to be much more stable compared to alternatives! 🎉 

The library works like this (simplified pseuducode):

```
start() {
    isRunning = true;
    fd = udev_monitor_get_fd();
    start_polling();
}
stop() {
    isRunning = false;
    destroy_udev();  <-- destroys fd
}
poll() {
    while (isRunning) {
        poll(fd, 100ms);
    }
}
```

When we call `stop`, the device `fd` is destroyed because we destroy `udev` handle, however if we're still using this `fd` in `poll`, it causes SIGSEGV in Electron. It doesn't repeat in node.js, no idea why.

Simple PoC:
```js
const { app, BrowserWindow } = require('electron');

app.whenReady().then(() => {
    const win = new BrowserWindow({ width: 800, height: 600 });
    win.loadURL('https://example.com');

    const mod = require('.');
    
    mod.startMonitoring();
    console.log('started');
    setTimeout(() => {
        mod.stopMonitoring();
        console.log('stopped');
        app.quit();
    }, 1000);
});
```

Compile it with:
```sh
npm i electron-rebuild
node_modules/.bin/electron-rebuild --version 12.0.0 --only .
node_modules/.bin/electron electron-test.js
```

Result (not always, repeat it several times):
```
started
stopped
~/node-usb-detection/node_modules/electron/dist/electron exited with signal SIGSEGV
```

This change moves destroying of the library handle to the callback that's called after "work" is complete.

While this is not critical because `stopMonitoring` must be called before exit, it's better if the app quits correctly instead of crashing.

I've tested only a simple case and I assume, this needs a bit more extensive testing.