### PR TITLE
fix(linux): segfault on close

### DIFF
--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -85,20 +85,11 @@ void Start() {
 }
 
 void Stop() {
-	if(!isRunning) {
-		return;
-	}
-
+//	if(!isRunning) {
+//		return;
+//	}
+//
 	isRunning = false;
-
-	uv_mutex_destroy(&notify_mutex);
-	uv_signal_stop(&int_signal);
-	uv_signal_stop(&term_signal);
-	uv_close((uv_handle_t *) &async_handler, NULL);
-	uv_cond_destroy(&notifyDeviceHandled);
-
-	udev_monitor_unref(mon);
-	udev_unref(udev);
 }
 
 void InitDetection() {
@@ -244,7 +235,14 @@ static void cbWork(uv_work_t *req) {
 }
 
 static void cbAfter(uv_work_t *req, int status) {
-	Stop();
+	uv_mutex_destroy(&notify_mutex);
+	uv_signal_stop(&int_signal);
+	uv_signal_stop(&term_signal);
+	uv_close((uv_handle_t *) &async_handler, NULL);
+	uv_cond_destroy(&notifyDeviceHandled);
+
+	udev_monitor_unref(mon);
+	udev_unref(udev);
 }
 
 static void cbAsync(uv_async_t *handle) {


### PR DESCRIPTION
On Linux, stopping or closing a program causes a segfault, since resources are freed before the thread terminates. Since this no longer affects the operation of the program, many did not notice this behavior.
