### PR TITLE
Update node-abi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2019,9 +2019,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.0.tgz",
+      "integrity": "sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==",
       "requires": {
         "semver": "^5.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chalk": "^2.4.1",
     "eslint": "^4.19.1",
     "jasmine": "^3.1.0",
-    "node-abi": "^2.19.3",
+    "node-abi": "^2.30.0",
     "node-gyp": "^6.1.0",
     "prebuild": "^10.0.0"
   }


### PR DESCRIPTION
PR updates `node-abi` to the latest version `2.30.0` to accommodate the latest version of Electron (v13). 