### PR TITLE
feat: [linux] expose devnum and busnum

### DIFF
--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -168,8 +168,8 @@ static ListResultItem_t* GetProperties(struct udev_device* dev, ListResultItem_t
 	}
 	item->vendorId = strtol(udev_device_get_sysattr_value(dev,"idVendor"), NULL, 16);
 	item->productId = strtol(udev_device_get_sysattr_value(dev,"idProduct"), NULL, 16);
-	item->deviceAddress = 0;
-	item->locationId = 0;
+	item->deviceAddress = strtol(udev_device_get_sysattr_value(dev,"devnum"), NULL, 10);
+	item->locationId = strtol(udev_device_get_sysattr_value(dev,"busnum"), NULL, 10);
 
 	return item;
 }
@@ -317,8 +317,8 @@ static void BuildInitialDeviceList() {
 		if(udev_device_get_sysattr_value(dev,"serial") != NULL) {
 			item->deviceParams.serialNumber = udev_device_get_sysattr_value(dev, "serial");
 		}
-		item->deviceParams.deviceAddress = 0;
-		item->deviceParams.locationId = 0;
+		item->deviceParams.deviceAddress = strtol(udev_device_get_sysattr_value(dev,"devnum"), NULL, 10);
+		item->deviceParams.locationId = strtol(udev_device_get_sysattr_value(dev,"busnum"), NULL, 10);
 
 		item->deviceState = DeviceState_Connect;
 


### PR DESCRIPTION
Hello,

this commit exposes the devnum and busnum to the library.
I use this to get the path for the device on ubuntu for udev.

Before this change the `device.deviceAddress` and `device.locationId` were set to zero.

---

Related to https://github.com/MadLittleMods/node-usb-detection/issues/8 and https://github.com/MadLittleMods/node-usb-detection/issues/51
