### PR TITLE
Fix segfault crash after `stopMonitoring` on Linux v2

### DIFF
--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -89,16 +89,13 @@ void Stop() {
 		return;
 	}
 
-	isRunning = false;
-
 	uv_mutex_destroy(&notify_mutex);
 	uv_signal_stop(&int_signal);
 	uv_signal_stop(&term_signal);
 	uv_close((uv_handle_t *) &async_handler, NULL);
 	uv_cond_destroy(&notifyDeviceHandled);
-
-	udev_monitor_unref(mon);
-	udev_unref(udev);
+	
+	isRunning = false;
 }
 
 void InitDetection() {
@@ -244,6 +241,9 @@ static void cbWork(uv_work_t *req) {
 }
 
 static void cbAfter(uv_work_t *req, int status) {
+	udev_monitor_unref(mon);
+	udev_unref(udev);
+
 	Stop();
 }
 

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -233,7 +233,6 @@ static void cbWork(uv_work_t *req) {
 		}
 	}
 
-
 	udev_monitor_unref(mon);
 	udev_unref(udev);
 	uv_mutex_destroy(&notify_mutex);

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -90,14 +90,6 @@ void Stop() {
 	}
 
 	isRunning = false;
-
-	udev_monitor_unref(mon);
-	udev_unref(udev);
-	uv_mutex_destroy(&notify_mutex);
-	uv_signal_stop(&int_signal);
-	uv_signal_stop(&term_signal);
-	uv_close((uv_handle_t *) &async_handler, NULL);
-	uv_cond_destroy(&notifyDeviceHandled);
 }
 
 void InitDetection() {
@@ -240,6 +232,15 @@ static void cbWork(uv_work_t *req) {
 			udev_device_unref(dev);
 		}
 	}
+
+
+	udev_monitor_unref(mon);
+	udev_unref(udev);
+	uv_mutex_destroy(&notify_mutex);
+	uv_signal_stop(&int_signal);
+	uv_signal_stop(&term_signal);
+	uv_close((uv_handle_t *) &async_handler, NULL);
+	uv_cond_destroy(&notifyDeviceHandled);
 }
 
 static void cbAfter(uv_work_t *req, int status) {

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -88,6 +88,7 @@ void Stop() {
 	if(!isRunning) {
 		return;
 	}
+
 	isRunning = false;
 
 	udev_monitor_unref(mon);
@@ -97,7 +98,6 @@ void Stop() {
 	uv_signal_stop(&term_signal);
 	uv_close((uv_handle_t *) &async_handler, NULL);
 	uv_cond_destroy(&notifyDeviceHandled);
-	
 }
 
 void InitDetection() {
@@ -243,7 +243,6 @@ static void cbWork(uv_work_t *req) {
 }
 
 static void cbAfter(uv_work_t *req, int status) {
-
 	Stop();
 }
 

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -88,14 +88,16 @@ void Stop() {
 	if(!isRunning) {
 		return;
 	}
+	isRunning = false;
 
+	udev_monitor_unref(mon);
+	udev_unref(udev);
 	uv_mutex_destroy(&notify_mutex);
 	uv_signal_stop(&int_signal);
 	uv_signal_stop(&term_signal);
 	uv_close((uv_handle_t *) &async_handler, NULL);
 	uv_cond_destroy(&notifyDeviceHandled);
 	
-	isRunning = false;
 }
 
 void InitDetection() {
@@ -241,8 +243,6 @@ static void cbWork(uv_work_t *req) {
 }
 
 static void cbAfter(uv_work_t *req, int status) {
-	udev_monitor_unref(mon);
-	udev_unref(udev);
 
 	Stop();
 }

--- a/src/detection_linux.cpp
+++ b/src/detection_linux.cpp
@@ -233,6 +233,7 @@ static void cbWork(uv_work_t *req) {
 		}
 	}
 
+	// After the loop stops running, clean up all of our references and close gracefully
 	udev_monitor_unref(mon);
 	udev_unref(udev);
 	uv_mutex_destroy(&notify_mutex);


### PR DESCRIPTION
Fix https://github.com/MadLittleMods/node-usb-detection/issues/57

Keeps @antelle's contributions in tree from https://github.com/MadLittleMods/node-usb-detection/pull/138 and incorporates @MadLittleMods and @Julusian's requested changes (I think).

I've confirmed this still fixes the segfault issue on Debian 11/Node 12, but not much beyond that.

~~Furthermore, the tests don't all pass, but it appears they don't in the main repo either.~~