### PR TITLE
Fix GitHub Actions CI failing on Windows runners (prebuild failing to build binaries)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,12 @@ jobs:
       # For Windows and npm <= 6
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
-        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@^8
+        run: "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\" && cd node_modules\\npm\\node_modules\\npm-lifecycle && npm install node-gyp@^8"
         shell: cmd
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
-        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@^8
+        run: "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\" && cd node_modules\\npm\\node_modules\@npmcli\\run-script && npm install node-gyp@^8"
         shell: cmd
 
       - name: 'Install Linux dependencies'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.arch }}
 
-      # See https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
+      # See
+      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
+      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Force-npm-to-use-global-node-gyp.md
       # For macOS/Linux and npm <= 6
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os != 'windows' && (matrix.node == '12' || matrix.node == '14') }}
@@ -46,9 +48,8 @@ jobs:
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: |
-          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
-          cd node_modules\\npm\\node_modules\\npm-lifecycle
-          npm install node-gyp@^8
+          npm install --global node-gyp@latest
+          for /f "delims=" %P in ('npm prefix -g') do npm config set node_gyp "%P\node_modules\node-gyp\bin\node-gyp.js"
         shell: cmd
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp@^8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,22 +35,22 @@ jobs:
 
       # See https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
       # For macOS/Linux and npm <= 6
-      - name: 'Install the latest version of node-gyp'
+      - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os != 'windows' && (matrix.node == '12' || matrix.node == '14') }}
-        run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@latest
+        run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@^8
       # For macOS/Linux and npm >= 7
-      - name: 'Install the latest version of node-gyp'
+      - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os != 'windows' && (matrix.node == '16') }}
-        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
+        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@^8
       # For Windows and npm <= 6
-      - name: 'Install the latest version of node-gyp'
+      - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
-        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@latest
+        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@^8
         shell: cmd
       # For Windows and npm >= 7
-      - name: 'Install the latest version of node-gyp'
+      - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
-        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@latest
+        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@^8
         shell: cmd
 
       - name: 'Install Linux dependencies'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,45 +33,8 @@ jobs:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.arch }}
 
-      # Make sure the build is using the latest version of node-gyp (which also
-      # matches our package.json) to ensure maximum build compatibility and
-      # avoid random build errors.
-      #
-      # See
-      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
-      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Force-npm-to-use-global-node-gyp.md
-      #
-      # For macOS/Linux and npm <= 6
-      - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os != 'Windows' && (matrix.node == '12' || matrix.node == '14') }}
-        run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@^8
-      # For macOS/Linux and npm >= 7
-      - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os != 'Windows' && (matrix.node == '16') }}
-        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@^8
-      # For Windows and npm <= 6
-      - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os == 'Windows' && (matrix.node == '12' || matrix.node == '14') }}
-        run: |
-          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
-          cd node_modules\\npm\\node_modules\\npm-lifecycle
-          npm install node-gyp@^8
-          npm install --global node-gyp@^8
-          for /f "delims=" %P in ('npm prefix -g') do npm config set node_gyp "%P\node_modules\node-gyp\bin\node-gyp.js"
-        shell: cmd
-      # For Windows and npm >= 7
-      - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os == 'Windows' && (matrix.node == '16') }}
-        run: |
-          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
-          cd node_modules\\npm\\node_modules\\@npmcli\\run-script
-          npm install node-gyp@^8
-        shell: cmd
-
-      # See https://github.com/nodejs/node-gyp/tree/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs#issues-finding-the-installed-visual-studio
-      - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
-        if: ${{ matrix.os == 'Windows' }}
-        run: npm config set msvs_version 2022
+      - name: 'Install npm@^8 to get a more up to date bundled node-gyp'
+        run: npm install npm@^8
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,14 @@ jobs:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.arch }}
 
+      # Make sure the build is using the latest version of node-gyp (which also
+      # matches our package.json) to ensure maximum build compatibility and
+      # avoid random build errors.
+      #
       # See
       # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
       # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Force-npm-to-use-global-node-gyp.md
+      #
       # For macOS/Linux and npm <= 6
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os != 'windows' && (matrix.node == '12' || matrix.node == '14') }}
@@ -48,6 +53,9 @@ jobs:
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: |
+          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
+          cd node_modules\\npm\\node_modules\\npm-lifecycle
+          npm install node-gyp@^8
           npm install --global node-gyp@latest
           for /f "delims=" %P in ('npm prefix -g') do npm config set node_gyp "%P\node_modules\node-gyp\bin\node-gyp.js"
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,15 @@ jobs:
       #
       # For macOS/Linux and npm <= 6
       - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os != 'windows' && (matrix.node == '12' || matrix.node == '14') }}
+        if: ${{ matrix.os != 'Windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@^8
       # For macOS/Linux and npm >= 7
       - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os != 'windows' && (matrix.node == '16') }}
+        if: ${{ matrix.os != 'Windows' && (matrix.node == '16') }}
         run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@^8
       # For Windows and npm <= 6
       - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
+        if: ${{ matrix.os == 'Windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: |
           "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
           cd node_modules\\npm\\node_modules\\npm-lifecycle
@@ -61,12 +61,17 @@ jobs:
         shell: cmd
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp@^8'
-        if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
+        if: ${{ matrix.os == 'Windows' && (matrix.node == '16') }}
         run: |
           "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
           cd node_modules\\npm\\node_modules\\@npmcli\\run-script
           npm install node-gyp@^8
         shell: cmd
+
+      # See https://github.com/nodejs/node-gyp/tree/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs#issues-finding-the-installed-visual-studio
+      - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
+        if: ${{ matrix.os == 'Windows' }}
+        run: npm config set msvs_version 2022
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       - name: 'Install npm@^8 to get a more up to date bundled node-gyp'
         run: npm install --global npm@8.3.1
 
+      # Fix `Error: Could not find any Visual Studio installation to use`
+      # See https://github.com/nodejs/node-gyp/tree/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs#issues-finding-the-installed-visual-studio
+      - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
+        if: ${{ matrix.os == 'Windows' }}
+        run: npm config set msvs_version 2022
+
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install libudev-dev
 
+      - name: 'Node.js version'
+        run: node --version
+
+      - name: 'node-gyp version'
+        run: npm run node-gyp --version
+
+      - name: 'node-gyp configuration'
+        run: npm run node-gyp configure --verbose
+
       - name: 'Install dependencies and build from source'
         run: npm ci --build-from-source
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
       # For Windows and npm <= 6
       - name: 'Install the latest version of node-gyp'
         if: ${{ matrix.os == 'windows' && (matrix.node === '12' || matrix.node === '14') }}
-        run: @FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@latest
+        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@latest
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp'
         if: ${{ matrix.os == 'windows' && (matrix.node === '16') }}
-        run: @FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@latest
+        run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@latest
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,35 @@ on: [push, pull_request]
 jobs:
   build:
     name: 'Build on Node v${{ matrix.node }} ${{ matrix.os }} ${{ matrix.arch }}'
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
 
     strategy:
       matrix:
         os: [Ubuntu, Windows, macOS]
+        os_version: [latest]
         arch: [x64]
         node: ['12', '14', '16']
         include:
           - os: Windows
             arch: x86
             node: '12'
+            # Using the `windows-2019` runner instead of latest(`windows-2022`)
+            # because the build was last known working on that version of runner and
+            # `prebuild` fails to find the 2022 Visual Studio install because
+            # it's internally using an old version of `node-gyp`, see
+            # https://github.com/prebuild/prebuild/issues/286
+            #
+            # Also some more context around this problem in this internal issue,
+            # https://github.com/MadLittleMods/node-usb-detection/issues/164
+            os_version: 2019
           - os: Windows
             arch: x86
             node: '14'
+            os_version: 2019
           - os: Windows
             arch: x86
             node: '16'
+            os_version: 2019
 
     steps:
       - name: 'Checkout repository'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.arch }}
 
-      # FIXME: Install latest v8 once
+      # FIXME: Install `npm@^8` (latest v8) once
       # https://github.com/actions/setup-node/issues/411#issuecomment-1025543081
       # is fixed.
       #
@@ -60,9 +60,11 @@ jobs:
 
       # Fix `Error: Could not find any Visual Studio installation to use`
       # See https://github.com/nodejs/node-gyp/tree/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs#issues-finding-the-installed-visual-studio
-      - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
-        if: ${{ matrix.os == 'Windows' }}
-        run: npm config set msvs_version 2022
+      #
+      # This is commented out because we're using `windows-2019` runners atm
+      # - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
+      #   if: ${{ matrix.os == 'Windows' }}
+      #   run: npm config set msvs_version 2022
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.arch }}
 
+      # FIXME: Install latest v8 once
+      # https://github.com/actions/setup-node/issues/411#issuecomment-1025543081
+      # is fixed.
+      #
+      # Even though we install a new version of node-gyp locally in
+      # the project, the CI always seems to use the npm bundled version of
+      # node-gyp. Even following the instructions from the docs, I could get it working
+      # on all other platforms except for Windows and npm@6, see
+      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
+      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Force-npm-to-use-global-node-gyp.md
       - name: 'Install npm@^8 to get a more up to date bundled node-gyp'
         run: npm install --global npm@8.3.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           architecture: ${{ matrix.arch }}
 
       - name: 'Install npm@^8 to get a more up to date bundled node-gyp'
-        run: npm install npm@^8 --global
+        run: npm install --global npm@8.3.1
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           architecture: ${{ matrix.arch }}
 
       - name: 'Install npm@^8 to get a more up to date bundled node-gyp'
-        run: npm install npm@^8
+        run: npm install npm@^8 --global
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
-        run: "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\" && cd node_modules\\npm\\node_modules\@npmcli\\run-script && npm install node-gyp@^8"
+        run: "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\" && cd node_modules\\npm\\node_modules\\@npmcli\\run-script && npm install node-gyp@^8"
         shell: cmd
 
       - name: 'Install Linux dependencies'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,12 @@ jobs:
       - name: 'Install the latest version of node-gyp'
         if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@latest
+        shell: cmd
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp'
         if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
         run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@latest
+        shell: cmd
 
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,13 @@ jobs:
       - name: 'node-gyp version'
         run: npm run node-gyp --version
 
-      - name: 'node-gyp configuration'
-        run: npm run node-gyp configure --verbose
-
       - name: 'Install dependencies and build from source'
         run: npm ci --build-from-source
+
+      # We run this after `npm ci` so that `nan` is installed probably
+      - name: 'node-gyp configuration (for debugging)'
+        if: ${{ always() }}
+        run: npm run node-gyp configure --verbose
 
       # TODO: Tests are disabled until we have tests which are
       # suitable for CI and don't require manual interaction.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,18 @@ jobs:
       # For Windows and npm <= 6
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
-        run: "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\" && cd node_modules\\npm\\node_modules\\npm-lifecycle && npm install node-gyp@^8"
+        run: |
+          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
+          cd node_modules\\npm\\node_modules\\npm-lifecycle
+          npm install node-gyp@^8
         shell: cmd
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp@^8'
         if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
-        run: "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\" && cd node_modules\\npm\\node_modules\\@npmcli\\run-script && npm install node-gyp@^8"
+        run: |
+          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
+          cd node_modules\\npm\\node_modules\\@npmcli\\run-script
+          npm install node-gyp@^8
         shell: cmd
 
       - name: 'Install Linux dependencies'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
           cd node_modules\\npm\\node_modules\\npm-lifecycle
           npm install node-gyp@^8
-          npm install --global node-gyp@latest
+          npm install --global node-gyp@^8
           for /f "delims=" %P in ('npm prefix -g') do npm config set node_gyp "%P\node_modules\node-gyp\bin\node-gyp.js"
         shell: cmd
       # For Windows and npm >= 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: 'Build on Node v${{ matrix.node }} ${{ matrix.os }} ${{ matrix.arch }}'
-    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
+    name: 'Build on Node v${{ matrix.node }} ${{ matrix.os.name }} ${{ matrix.arch }}'
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
 
     strategy:
       matrix:
-        os: [Ubuntu, Windows, macOS]
-        os_version: [latest]
-        arch: [x64]
-        node: ['12', '14', '16']
-        include:
-          - os: Windows
-            arch: x86
-            node: '12'
+        os:
+          - name: Ubuntu
+            version: latest
+          - name: macOS
+            version: latest
+          - name: Windows
             # Using the `windows-2019` runner instead of latest(`windows-2022`)
             # because the build was last known working on that version of runner and
             # `prebuild` fails to find the 2022 Visual Studio install because
@@ -25,15 +23,25 @@ jobs:
             #
             # Also some more context around this problem in this internal issue,
             # https://github.com/MadLittleMods/node-usb-detection/issues/164
-            os_version: 2019
-          - os: Windows
+            version: 2019
+        arch: [x64]
+        node: ['12', '14', '16']
+        include:
+          - os:
+              name: Windows
+              version: 2019
+            arch: x86
+            node: '12'
+          - os: 
+              name: Windows
+              version: 2019
             arch: x86
             node: '14'
-            os_version: 2019
-          - os: Windows
+          - os: 
+              name: Windows
+              version: 2019
             arch: x86
             node: '16'
-            os_version: 2019
 
     steps:
       - name: 'Checkout repository'
@@ -63,11 +71,11 @@ jobs:
       #
       # This is commented out because we're using `windows-2019` runners atm
       # - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
-      #   if: ${{ matrix.os == 'Windows' }}
+      #   if: ${{ matrix.os.name == 'Windows' }}
       #   run: npm config set msvs_version 2022
 
       - name: 'Install Linux dependencies'
-        if: ${{ matrix.os == 'Ubuntu' }}
+        if: ${{ matrix.os.name == 'Ubuntu' }}
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev
@@ -104,7 +112,7 @@ jobs:
         if: ${{ matrix.node == '14' }}
         uses: actions/upload-artifact@v2
         with:
-          name: prebuilds-${{ matrix.os }}-${{ matrix.arch }}
+          name: prebuilds-${{ matrix.os.name }}-${{ matrix.arch }}
           path: prebuilds
 
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,24 @@ jobs:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.arch }}
 
+      # See https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
+      # For macOS/Linux and npm <= 6
+      - name: 'Install the latest version of node-gyp'
+        if: ${{ matrix.os != 'windows' && (matrix.node === '12' || matrix.node === '14') }}
+        run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@latest
+      # For macOS/Linux and npm >= 7
+      - name: 'Install the latest version of node-gyp'
+        if: ${{ matrix.os != 'windows' && (matrix.node === '16') }}
+        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
+      # For Windows and npm <= 6
+      - name: 'Install the latest version of node-gyp'
+        if: ${{ matrix.os == 'windows' && (matrix.node === '12' || matrix.node === '14') }}
+        run: @FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@latest
+      # For Windows and npm >= 7
+      - name: 'Install the latest version of node-gyp'
+        if: ${{ matrix.os == 'windows' && (matrix.node === '16') }}
+        run: @FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@latest
+
       - name: 'Install Linux dependencies'
         if: ${{ matrix.os == 'Ubuntu' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: 'Node.js version'
         run: node --version
 
+      - name: 'npm version'
+        run: npm --version
+
       - name: 'node-gyp version'
         run: npm run node-gyp --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,19 @@ jobs:
       # See https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
       # For macOS/Linux and npm <= 6
       - name: 'Install the latest version of node-gyp'
-        if: ${{ matrix.os != 'windows' && (matrix.node === '12' || matrix.node === '14') }}
+        if: ${{ matrix.os != 'windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@latest
       # For macOS/Linux and npm >= 7
       - name: 'Install the latest version of node-gyp'
-        if: ${{ matrix.os != 'windows' && (matrix.node === '16') }}
+        if: ${{ matrix.os != 'windows' && (matrix.node == '16') }}
         run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
       # For Windows and npm <= 6
       - name: 'Install the latest version of node-gyp'
-        if: ${{ matrix.os == 'windows' && (matrix.node === '12' || matrix.node === '14') }}
+        if: ${{ matrix.os == 'windows' && (matrix.node == '12' || matrix.node == '14') }}
         run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\npm-lifecycle && npm install node-gyp@latest
       # For Windows and npm >= 7
       - name: 'Install the latest version of node-gyp'
-        if: ${{ matrix.os == 'windows' && (matrix.node === '16') }}
+        if: ${{ matrix.os == 'windows' && (matrix.node == '16') }}
         run: \@FOR /f "tokens=*" %i IN ('where node') DO cd/d "%~dpi" && cd node_modules\npm\node_modules\@npmcli\run-script && npm install node-gyp@latest
 
       - name: 'Install Linux dependencies'
@@ -64,7 +64,7 @@ jobs:
         run: npm --version
 
       - name: 'node-gyp version'
-        run: npm run node-gyp --version
+        run: npm run node-gyp -- --version
 
       - name: 'Install dependencies and build from source'
         run: npm ci --build-from-source
@@ -72,7 +72,7 @@ jobs:
       # We run this after `npm ci` so that `nan` is installed probably
       - name: 'node-gyp configuration (for debugging)'
         if: ${{ always() }}
-        run: npm run node-gyp configure --verbose
+        run: npm run node-gyp -- configure --verbose
 
       # TODO: Tests are disabled until we have tests which are
       # suitable for CI and don't require manual interaction.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,31 +13,31 @@
         "bindings": "^1.5.0",
         "eventemitter2": "^5.0.1",
         "nan": "^2.15.0",
-        "prebuild-install": "^6.1.4"
+        "prebuild-install": "^7.0.1"
       },
       "devDependencies": {
         "chai": "^4.1.2",
         "chalk": "^2.4.1",
         "eslint": "^4.19.1",
         "jasmine": "^3.1.0",
-        "node-abi": "^3.1.0",
-        "node-gyp": "^8.2.0",
-        "prebuild": "^11.0.0"
+        "node-abi": "^3.8.0",
+        "node-gyp": "^8.4.0",
+        "prebuild": "^11.0.3"
       },
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@gar/promisify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
     "node_modules/@npmcli/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "dev": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/agentkeepalive": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/cacache/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -1163,13 +1163,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -1182,14 +1189,17 @@
       }
     },
     "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dependencies": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/deep-eql": {
@@ -1260,14 +1270,11 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -2620,7 +2627,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2631,17 +2637,16 @@
     "node_modules/lru-cache/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/make-fetch-happen": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
-      "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
       "dev": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
-        "cacache": "^15.0.5",
+        "cacache": "^15.2.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -2652,8 +2657,9 @@
         "minipass-fetch": "^1.3.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^5.0.0",
+        "socks-proxy-agent": "^6.0.0",
         "ssri": "^8.0.0"
       },
       "engines": {
@@ -2661,9 +2667,9 @@
       }
     },
     "node_modules/make-fetch-happen/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2742,11 +2748,11 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2792,9 +2798,9 @@
       }
     },
     "node_modules/minipass-collect/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2827,9 +2833,9 @@
       }
     },
     "node_modules/minipass-fetch/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2870,9 +2876,9 @@
       }
     },
     "node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2900,9 +2906,9 @@
       }
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -2930,9 +2936,9 @@
       }
     },
     "node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -3013,6 +3019,15 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -3020,10 +3035,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.1.0.tgz",
-      "integrity": "sha512-kVF+eIDzPPwPcJdoVhWboJvdCe+YF1+rkd7+LeYmA95179T0sVB5kKG8VADM/3sBnGWeAUBR8FzH+whlksJTrQ==",
-      "dev": true,
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
+      "integrity": "sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -3035,7 +3049,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3047,15 +3060,15 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.2.0.tgz",
-      "integrity": "sha512-KG8SdcoAnw2d6augGwl1kOayALUrXW/P2uOAm2J2+nmW/HjZo7y+8TDg7LejxbekOOSv3kzhq+NSUYkIDAX8eA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.0.tgz",
+      "integrity": "sha512-Bi/oCm5bH6F+FmzfUxJpPaxMEyIhszULGR3TprmTeku8/dMFcdTcypk120NeZqEt54r1BrgEKtm2jJiuIKE28Q==",
       "dev": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^8.0.14",
+        "make-fetch-happen": "^9.1.0",
         "nopt": "^5.0.0",
         "npmlog": "^4.1.2",
         "rimraf": "^3.0.2",
@@ -3596,13 +3609,13 @@
       }
     },
     "node_modules/prebuild": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.0.tgz",
-      "integrity": "sha512-Vmr240YZZXTXOHFMvGrNaPN/PYFZSxKwiJNSxpwvW215B0mkhwHccVQHtklK4pXeXS80gYGpe5mt72zhKjBPQg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.3.tgz",
+      "integrity": "sha512-0synbTNdYD9nkVFtVl0nbslM6AefnKRcvyvtDwv6qswh4gYCbdWGmir4G7YPPDa3VmKCZADVBYnkqNI3qKJy5Q==",
       "dev": true,
       "dependencies": {
         "cmake-js": "~5.2.0",
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "each-series-async": "^1.0.1",
         "execspawn": "^1.0.1",
         "ghreleases": "^3.0.2",
@@ -3630,21 +3643,21 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
+      "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
       "dependencies": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
+        "node-abi": "^3.3.0",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -3652,15 +3665,7 @@
         "prebuild-install": "bin.js"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-      "dependencies": {
-        "semver": "^5.4.1"
+        "node": ">=10"
       }
     },
     "node_modules/prebuild/node_modules/glob": {
@@ -4099,6 +4104,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -4160,11 +4166,25 @@
       ]
     },
     "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
-        "decompress-response": "^4.2.0",
+        "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -4201,13 +4221,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
       "dev": true,
       "dependencies": {
         "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "smart-buffer": "^4.2.0"
       },
       "engines": {
         "node": ">= 10.13.0",
@@ -4215,17 +4235,17 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/source-map": {
@@ -4300,9 +4320,9 @@
       }
     },
     "node_modules/ssri/node_modules/minipass": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -4967,15 +4987,15 @@
   },
   "dependencies": {
     "@gar/promisify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
     "@npmcli/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "dev": true,
       "requires": {
         "@gar/promisify": "^1.0.1",
@@ -5085,9 +5105,9 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -5500,9 +5520,9 @@
           }
         },
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -5896,12 +5916,12 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -5911,11 +5931,11 @@
       "dev": true
     },
     "decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "requires": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       }
     },
     "deep-eql": {
@@ -5971,9 +5991,9 @@
       "dev": true
     },
     "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "doctrine": {
       "version": "2.1.0",
@@ -7153,7 +7173,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       },
@@ -7161,19 +7180,18 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
     "make-fetch-happen": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
-      "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^4.1.3",
-        "cacache": "^15.0.5",
+        "cacache": "^15.2.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -7184,15 +7202,16 @@
         "minipass-fetch": "^1.3.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^5.0.0",
+        "socks-proxy-agent": "^6.0.0",
         "ssri": "^8.0.0"
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -7263,9 +7282,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7315,9 +7334,9 @@
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -7344,9 +7363,9 @@
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -7380,9 +7399,9 @@
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -7406,9 +7425,9 @@
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -7432,9 +7451,9 @@
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -7499,6 +7518,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -7506,10 +7531,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.1.0.tgz",
-      "integrity": "sha512-kVF+eIDzPPwPcJdoVhWboJvdCe+YF1+rkd7+LeYmA95179T0sVB5kKG8VADM/3sBnGWeAUBR8FzH+whlksJTrQ==",
-      "dev": true,
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
+      "integrity": "sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==",
       "requires": {
         "semver": "^7.3.5"
       },
@@ -7518,7 +7542,6 @@
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -7526,15 +7549,15 @@
       }
     },
     "node-gyp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.2.0.tgz",
-      "integrity": "sha512-KG8SdcoAnw2d6augGwl1kOayALUrXW/P2uOAm2J2+nmW/HjZo7y+8TDg7LejxbekOOSv3kzhq+NSUYkIDAX8eA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.0.tgz",
+      "integrity": "sha512-Bi/oCm5bH6F+FmzfUxJpPaxMEyIhszULGR3TprmTeku8/dMFcdTcypk120NeZqEt54r1BrgEKtm2jJiuIKE28Q==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^8.0.14",
+        "make-fetch-happen": "^9.1.0",
         "nopt": "^5.0.0",
         "npmlog": "^4.1.2",
         "rimraf": "^3.0.2",
@@ -7940,13 +7963,13 @@
       "dev": true
     },
     "prebuild": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.0.tgz",
-      "integrity": "sha512-Vmr240YZZXTXOHFMvGrNaPN/PYFZSxKwiJNSxpwvW215B0mkhwHccVQHtklK4pXeXS80gYGpe5mt72zhKjBPQg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.3.tgz",
+      "integrity": "sha512-0synbTNdYD9nkVFtVl0nbslM6AefnKRcvyvtDwv6qswh4gYCbdWGmir4G7YPPDa3VmKCZADVBYnkqNI3qKJy5Q==",
       "dev": true,
       "requires": {
         "cmake-js": "~5.2.0",
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "each-series-async": "^1.0.1",
         "execspawn": "^1.0.1",
         "ghreleases": "^3.0.2",
@@ -8064,33 +8087,23 @@
       }
     },
     "prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
+      "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
       "requires": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
+        "node-abi": "^3.3.0",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "node-abi": {
-          "version": "2.30.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-          "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-          "requires": {
-            "semver": "^5.4.1"
-          }
-        }
       }
     },
     "prelude-ls": {
@@ -8358,7 +8371,8 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -8397,11 +8411,11 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "requires": {
-        "decompress-response": "^4.2.0",
+        "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -8428,24 +8442,24 @@
       "dev": true
     },
     "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "smart-buffer": "^4.2.0"
       }
     },
     "socks-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "requires": {
         "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
       }
     },
     "source-map": {
@@ -8504,9 +8518,9 @@
       },
       "dependencies": {
         "minipass": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
-          "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "eslint **/*.js",
     "validate": "npm run lint && npm test",
     "test": "jasmine ./test/test.js",
-    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild": "npm run prebuild-node && npm run prebuild-electron",
+    "prebuild-node": "prebuild --force --strip --verbose -t 12.0.0 -t 14.0.0 -t 16.0.0",
+    "prebuild-electron": "prebuild --force --strip --verbose -r electron -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0",
     "prebuild-upload": "prebuild --upload-all",
     "rebuild": "node-gyp rebuild"
   },

--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
     "bindings": "^1.5.0",
     "eventemitter2": "^5.0.1",
     "nan": "^2.15.0",
-    "prebuild-install": "^6.1.4"
+    "prebuild-install": "^7.0.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "chalk": "^2.4.1",
     "eslint": "^4.19.1",
     "jasmine": "^3.1.0",
-    "node-abi": "^3.1.0",
-    "node-gyp": "^8.2.0",
-    "prebuild": "^11.0.0"
+    "node-abi": "^3.8.0",
+    "node-gyp": "^8.4.0",
+    "prebuild": "^11.0.3"
   }
 }


### PR DESCRIPTION
Fix GitHub Actions CI failing on Windows runners:

Fix https://github.com/MadLittleMods/node-usb-detection/issues/164


**Before** `windows-latest` -> `windows-2022`:
```
Error: Could not find any Visual Studio installation to use
```

**After** `windows-2019` ✅ 



### Dev notes

Default `npm` versions:

 - Node.js v12 -> `npm@6.14.16` -> `node-gyp@5.1.0`
 - Node.js v14 -> `npm@6.14.16` -> `node-gyp@5.1.0`
 - Node.js v16 -> `npm@8.3.1`  -> `node-gyp@5.1.0`
 
 
---
 
```yaml
      # Make sure the build is using the latest version of node-gyp (which also
      # matches our package.json) to ensure maximum build compatibility and
      # avoid random build errors.
      #
      # See
      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Updating-npm-bundled-node-gyp.md
      # - https://github.com/nodejs/node-gyp/blob/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs/Force-npm-to-use-global-node-gyp.md
      #
      # For macOS/Linux and npm <= 6
      - name: 'Install the latest version of node-gyp@^8'
        if: ${{ matrix.os != 'Windows' && (matrix.node == '12' || matrix.node == '14') }}
        run: npm explore npm/node_modules/npm-lifecycle -g -- npm install node-gyp@^8
      # For macOS/Linux and npm >= 7
      - name: 'Install the latest version of node-gyp@^8'
        if: ${{ matrix.os != 'Windows' && (matrix.node == '16') }}
        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@^8
      # For Windows and npm <= 6
      - name: 'Install the latest version of node-gyp@^8'
        if: ${{ matrix.os == 'Windows' && (matrix.node == '12' || matrix.node == '14') }}
        run: |
          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
          cd node_modules\\npm\\node_modules\\npm-lifecycle
          npm install node-gyp@^8
          npm install --global node-gyp@^8
          for /f "delims=" %P in ('npm prefix -g') do npm config set node_gyp "%P\node_modules\node-gyp\bin\node-gyp.js"
        shell: cmd
      # For Windows and npm >= 7
      - name: 'Install the latest version of node-gyp@^8'
        if: ${{ matrix.os == 'Windows' && (matrix.node == '16') }}
        run: |
          "@FOR /f \"tokens=*\" %i IN ('where node') DO cd/d \"%~dpi\""
          cd node_modules\\npm\\node_modules\\@npmcli\\run-script
          npm install node-gyp@^8
        shell: cmd

      # See https://github.com/nodejs/node-gyp/tree/245cd5bbe4441d4f05e88f2fa20a86425419b6af/docs#issues-finding-the-installed-visual-studio
      - name: 'Set msvs_version so node-gyp can find the Visual Studio install'
        if: ${{ matrix.os == 'Windows' }}
        run: npm config set msvs_version 2022
```