### PR TITLE
chore: add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 `usb-detection` allows you to listen for insert/remove events of USB devices on your system.
 
 
+## Deprecated
+
+This library is now deprecated. We recommend using [`usb`](https://github.com/node-usb/node-usb#migrating-from-node-usb-detection) for hotplug detection instead. It supports a wider range of platforms, using a more proven codebase. 
+
+For help migrating, refer to the [documentation for `usb`](https://github.com/node-usb/node-usb#migrating-from-node-usb-detection)
+
+
 ### [Changelog](https://github.com/MadLittleMods/node-usb-detection/blob/master/CHANGELOG.md)
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+
+
+# 🛑🛑 Deprecated 🛑🛑
+
+This library is now deprecated. We recommend using [`usb`](https://github.com/node-usb/node-usb#migrating-from-node-usb-detection) for hotplug detection instead. It supports a wider range of platforms, using a more proven codebase. 
+
+For help migrating, refer to the [documentation for `usb`](https://github.com/node-usb/node-usb#migrating-from-node-usb-detection)
+
+---
+
 [![npm version](https://badge.fury.io/js/usb-detection.svg)](http://badge.fury.io/js/usb-detection) [![Gitter](https://badges.gitter.im/MadLittleMods/node-usb-detection.svg)](https://gitter.im/MadLittleMods/node-usb-detection?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
@@ -5,12 +15,6 @@
 
 `usb-detection` allows you to listen for insert/remove events of USB devices on your system.
 
-
-## Deprecated
-
-This library is now deprecated. We recommend using [`usb`](https://github.com/node-usb/node-usb#migrating-from-node-usb-detection) for hotplug detection instead. It supports a wider range of platforms, using a more proven codebase. 
-
-For help migrating, refer to the [documentation for `usb`](https://github.com/node-usb/node-usb#migrating-from-node-usb-detection)
 
 
 ### [Changelog](https://github.com/MadLittleMods/node-usb-detection/blob/master/CHANGELOG.md)


### PR DESCRIPTION
As suggested in https://github.com/MadLittleMods/node-usb-detection/pull/127, I think it is time to think about deprecating this library.

https://github.com/node-usb/node-usb/releases/tag/v2.5.0 now supports native hotplug detection on a wider range of platforms, and will mitigate the very common issue users here have of node abi version mismatches, or missing prebuilds for new node/electron versions.
